### PR TITLE
Extend Gem with additional Template and Recipient Functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .bundle
 .config
 .yardoc
+.ruby-*
 Gemfile.lock
 InstalledFiles
 _yardoc

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: ruby
+rvm:
+- 2.0.0
+- 2.1.6
+- 2.2.1
+- 2.2.2
+cache:
+- bundler
+script: bundle exec rspec spec

--- a/README.md
+++ b/README.md
@@ -45,14 +45,14 @@ mail = SendGrid::Mail.new do |m|
   m.text = 'I heard you like pineapple.'
 end
 
-puts client.send(mail) 
+puts client.send(mail)
 # {"message":"success"}
 ```
 
 You can also create a Mail object with a hash:
 ```ruby
 client.send(SendGrid::Mail.new(to: 'example@example.com', from: 'taco@cat.limo', subject: 'Hello world!', text: 'Hi there!', html: '<b>Hi there!</b>'))
-	
+
 # {"message":"success"}
 ```
 
@@ -192,4 +192,4 @@ mail.smtpapi = header
 4. Push to the branch (`git push origin my-new-feature`)
 5. Create a new Pull Request
 
-***Hit up [@rbin](http://twitter.com/rbin) or [@eddiezane](http://twitter.com/eddiezane) on Twitter with any issues.***
+***Hit up [@rbin](http://twitter.com/rbin) on Twitter with any issues.***

--- a/README.md
+++ b/README.md
@@ -83,7 +83,6 @@ params = {
 }
 ```
 
-
 #### Setting Params
 
 Params can be set in the usual Ruby ways, including a block or a hash.
@@ -160,9 +159,58 @@ mail = SendGrid::Mail.new
 mail.html = '<html><body>Stuff in here, yo!</body></html>'
 ```
 
+## Working with Templates
+
+An easy way to use the [SendGrid Templating](https://sendgrid.com/docs/API_Reference/Web_API_v3/Template_Engine/index.html) system is with the `Recipient`, `Mail`, `Template`, and `TemplateMailer` objects.
+
+Create some `Recipients`
+
+```ruby
+users = User.where(email: ['first@gmail.com', 'second@gmail.com'])
+
+recipients = []
+
+users.each do |user|
+  recipient = SendGrid::Recipient.new(user.email)
+  recipient.add_substitution('first_name', user.first_name)
+  recipient.add_substitution('city', user.city)
+
+  recipients << recipient
+end
+```
+
+Create a `Template`
+
+```ruby
+template = SendGrid::Template.new('MY_TEMPLATE_ID')
+```
+
+Create a `Client`
+
+```ruby
+client = SendGrid::Client.new(api_user: my_user, api_key: my_key)
+```
+
+Initialize mail defaults and create the `TemplateMailer`
+
+```ruby
+mail_defaults = {
+  from: 'admin@email.com',
+  html: '<h1>I like email</h1>',
+  text: 'I like email'
+  subject: 'Email is great',
+}
+
+mailer = TemplateMailer.new(client, template, recipients)
+```
+
+Mail it!
+
+```ruby
+mailer.mail(mail_defaults)
+```
 
 ## Using SendGrid's X-SMTPAPI Header
-
 
 <blockquote>
 To utilize the X-SMTPAPI header, we have directly integrated the <a href="https://github.com/SendGridJP/smtpapi-ruby">SendGridJP/smtpapi-ruby</a> gem.

--- a/lib/sendgrid-ruby.rb
+++ b/lib/sendgrid-ruby.rb
@@ -1,5 +1,6 @@
 require_relative 'sendgrid/exceptions'
 require_relative 'sendgrid/template'
+require_relative 'sendgrid/template_mailer'
 require_relative 'sendgrid/mail'
 require_relative 'sendgrid/version'
 

--- a/lib/sendgrid-ruby.rb
+++ b/lib/sendgrid-ruby.rb
@@ -1,4 +1,5 @@
 require_relative 'sendgrid/exceptions'
+require_relative 'sendgrid/template'
 require_relative 'sendgrid/mail'
 require_relative 'sendgrid/version'
 

--- a/lib/sendgrid/mail.rb
+++ b/lib/sendgrid/mail.rb
@@ -33,11 +33,19 @@ module SendGrid
     end
 
     def to_h
-      payload = {}
-
-      PAYLOAD_PARAMS.each do |payload_param|
-        payload[payload_mapping(payload_param)] = self.send(payload_param)
-      end
+      payload = {
+        from: from,
+        fromname: from_name,
+        subject: subject,
+        to: to,
+        toname: to_name,
+        date: date,
+        replyto: reply_to,
+        cc: cc,
+        bcc: bcc,
+        text: text,
+        html: html
+      }
 
       payload.merge!({
         :'x-smtpapi' => smtpapi_json,
@@ -49,18 +57,6 @@ module SendGrid
       assign_missing_to(payload)
 
       payload
-    end
-
-    # This mapping is to ensure that keys in the request payload
-    #  match requirements. This enables the use of common idiomatic
-    #  ruby variables (snake_cased) within class logic and easy translation
-    #  for request preparation.
-    def payload_mapping(key)
-      {
-        from_name: :fromname,
-        to_name: :toname,
-        reply_to: :replyto,
-      }[key] || key
     end
 
     def assign_missing_to(payload)

--- a/lib/sendgrid/mail.rb
+++ b/lib/sendgrid/mail.rb
@@ -1,10 +1,11 @@
 require 'json'
 require 'smtpapi'
+require_relative './template'
 
 module SendGrid
   class Mail
-    attr_accessor :to, :to_name, :from, :from_name, :subject, :text, :html, :cc, 
-      :bcc, :reply_to, :date, :smtpapi, :attachments
+    attr_accessor :to, :to_name, :from, :from_name, :subject, :text, :html, :cc,
+      :bcc, :reply_to, :date, :smtpapi, :attachments, :template_id
 
     def initialize(params = {})
       params.each do |k, v|
@@ -39,7 +40,7 @@ module SendGrid
         :bcc         => @bcc,
         :text        => @text,
         :html        => @html,
-        :'x-smtpapi' => @smtpapi.to_json,
+        :'x-smtpapi' => smtpapi_json,
         :files       => ({} unless @attachments.empty?)
       }.reject {|k,v| v.nil?}
 
@@ -55,6 +56,22 @@ module SendGrid
       end
 
       payload
+    end
+
+    private
+
+    def template
+      return if template_id.nil?
+
+      @template ||= Template.new(template_id)
+    end
+
+    def smtpapi_json
+      if template
+        template.add_to_smtpapi(@smtpapi)
+      end
+
+      @smtpapi.to_json
     end
   end
 end

--- a/lib/sendgrid/mail.rb
+++ b/lib/sendgrid/mail.rb
@@ -5,7 +5,7 @@ require_relative './template'
 module SendGrid
   class Mail
     attr_accessor :to, :to_name, :from, :from_name, :subject, :text, :html, :cc,
-      :bcc, :reply_to, :date, :smtpapi, :attachments, :template_id
+      :bcc, :reply_to, :date, :smtpapi, :attachments, :template
 
     def initialize(params = {})
       params.each do |k, v|
@@ -58,16 +58,8 @@ module SendGrid
       payload
     end
 
-    private
-
-    def template
-      return if template_id.nil?
-
-      @template ||= Template.new(template_id)
-    end
-
     def smtpapi_json
-      if template
+      unless template.nil? && template.is_a?(Template)
         template.add_to_smtpapi(@smtpapi)
       end
 

--- a/lib/sendgrid/mail.rb
+++ b/lib/sendgrid/mail.rb
@@ -59,7 +59,7 @@ module SendGrid
     end
 
     def smtpapi_json
-      unless template.nil? && template.is_a?(Template)
+      if !template.nil? && template.is_a?(Template)
         template.add_to_smtpapi(@smtpapi)
       end
 

--- a/lib/sendgrid/mail.rb
+++ b/lib/sendgrid/mail.rb
@@ -4,13 +4,18 @@ require_relative './template'
 
 module SendGrid
   class Mail
-    attr_accessor :to, :to_name, :from, :from_name, :subject, :text, :html, :cc,
-      :bcc, :reply_to, :date, :smtpapi, :attachments, :template
+
+    PAYLOAD_PARAMS = %i[bcc cc date from from_name html reply_to subject text to to_name].freeze
+
+    MAIL_PARAMS = (PAYLOAD_PARAMS + %i[attachments smtpapi headers template]).freeze
+
+    attr_accessor *MAIL_PARAMS
 
     def initialize(params = {})
-      params.each do |k, v|
-        instance_variable_set("@#{k}", v) unless v.nil?
+      MAIL_PARAMS.each do |mail_param|
+        self.send("#{mail_param}=", params[mail_param]) unless params[mail_param].nil?
       end
+
       @headers     ||= {}
       @attachments ||= []
       @smtpapi     ||= Smtpapi::Header.new
@@ -28,34 +33,51 @@ module SendGrid
     end
 
     def to_h
-      payload = {
-        :from        => @from,
-        :fromname    => @from_name,
-        :subject     => @subject,
-        :to          => @to,
-        :toname      => @to_name,
-        :date        => @date,
-        :replyto     => @reply_to,
-        :cc          => @cc,
-        :bcc         => @bcc,
-        :text        => @text,
-        :html        => @html,
-        :'x-smtpapi' => smtpapi_json,
-        :files       => ({} unless @attachments.empty?)
-      }.reject {|k,v| v.nil?}
+      payload = {}
 
+      PAYLOAD_PARAMS.each do |payload_param|
+        payload[payload_mapping(payload_param)] = self.send(payload_param)
+      end
+
+      payload.merge!({
+        :'x-smtpapi' => smtpapi_json,
+        :files       => extract_attachments(payload)
+      })
+
+      payload.reject! {|k,v| v.nil?}
+
+      assign_missing_to(payload)
+
+      payload
+    end
+
+    # This mapping is to ensure that keys in the request payload
+    #  match requirements. This enables the use of common idiomatic
+    #  ruby variables (snake_cased) within class logic and easy translation
+    #  for request preparation.
+    def payload_mapping(key)
+      {
+        from_name: :fromname,
+        to_name: :toname,
+        reply_to: :replyto,
+      }[key] || key
+    end
+
+    def assign_missing_to(payload)
       # smtpapi fixer
       if @to.nil? and not @smtpapi.to.empty?
         payload[:to] = payload[:from]
       end
+    end
 
-      unless @attachments.empty?
+    def extract_attachments(payload)
+      return if @attachments.empty?
+
+      {}.tap do |files|
         @attachments.each do |file|
-          payload[:files][file[:name]] = file[:file]
+          files[file[:name]] = file[:file]
         end
       end
-
-      payload
     end
 
     def smtpapi_json

--- a/lib/sendgrid/recipient.rb
+++ b/lib/sendgrid/recipient.rb
@@ -21,7 +21,8 @@ module SendGrid
       smtpapi.add_to(@address)
 
       @substitutions.each do |key, value|
-        smtpapi.add_substitution(key, [value])
+        existing = smtpapi.sub[key] || []
+        smtpapi.add_substitution(key, existing + [value])
       end
     end
   end

--- a/lib/sendgrid/recipient.rb
+++ b/lib/sendgrid/recipient.rb
@@ -1,0 +1,26 @@
+require 'smtpapi'
+
+module SendGrid
+  class Recipient
+
+    attr_reader :address, :substitutions
+
+    def initialize(address)
+      @address = address
+      @substitutions = {}
+    end
+
+    def add_substitution(key, value)
+      substitutions[key.to_sym] = value
+    end
+
+    def add_to_smtpapi(smtpapi)
+      return if @address.nil? || @substitutions.empty?
+      smtpapi.add_to(@address)
+
+      @substitutions.each do |key, value|
+        smtpapi.add_substitution(key, value)
+      end
+    end
+  end
+end

--- a/lib/sendgrid/recipient.rb
+++ b/lib/sendgrid/recipient.rb
@@ -14,14 +14,14 @@ module SendGrid
     end
 
     def add_substitution(key, value)
-      substitutions[key.to_sym] = value
+      substitutions[key] = value
     end
 
     def add_to_smtpapi(smtpapi)
       smtpapi.add_to(@address)
 
       @substitutions.each do |key, value|
-        smtpapi.add_substitution(key, value)
+        smtpapi.add_substitution(key, [value])
       end
     end
   end

--- a/lib/sendgrid/recipient.rb
+++ b/lib/sendgrid/recipient.rb
@@ -2,12 +2,15 @@ require 'smtpapi'
 
 module SendGrid
   class Recipient
+    class NoAddress < StandardError; end
 
     attr_reader :address, :substitutions
 
     def initialize(address)
       @address = address
       @substitutions = {}
+
+      raise NoAddress, 'Recipient address cannot be nil' if @address.nil?
     end
 
     def add_substitution(key, value)
@@ -15,7 +18,6 @@ module SendGrid
     end
 
     def add_to_smtpapi(smtpapi)
-      return if @address.nil? || @substitutions.empty?
       smtpapi.add_to(@address)
 
       @substitutions.each do |key, value|

--- a/lib/sendgrid/template.rb
+++ b/lib/sendgrid/template.rb
@@ -18,8 +18,8 @@ module SendGrid
       return if smtpapi.nil?
 
       smtpapi.tap do |api|
-        api.add_filter(:template, :enabled, 1)
-        api.add_filter(:template, :id, id)
+        api.add_filter(:templates, :enable, 1)
+        api.add_filter(:templates, :template_id, id)
         recipients.each { |r| r.add_to_smtpapi(smtpapi) }
       end
     end

--- a/lib/sendgrid/template.rb
+++ b/lib/sendgrid/template.rb
@@ -1,11 +1,17 @@
 require 'smtpapi'
+require_relative './recipient'
 
 module SendGrid
   class Template
-    attr_reader :id
+    attr_reader :id, :recipients
 
     def initialize(id)
       @id = id
+      @recipients = []
+    end
+
+    def add_recipient(recipient)
+      recipients << recipient
     end
 
     def add_to_smtpapi(smtpapi)
@@ -14,6 +20,7 @@ module SendGrid
       smtpapi.tap do |api|
         api.add_filter(:template, :enabled, 1)
         api.add_filter(:template, :id, id)
+        recipients.each { |r| r.add_to_smtpapi(smtpapi) }
       end
     end
   end

--- a/lib/sendgrid/template.rb
+++ b/lib/sendgrid/template.rb
@@ -1,0 +1,20 @@
+require 'smtpapi'
+
+module SendGrid
+  class Template
+    attr_reader :id
+
+    def initialize(id)
+      @id = id
+    end
+
+    def add_to_smtpapi(smtpapi)
+      return if smtpapi.nil?
+
+      smtpapi.tap do |api|
+        api.add_filter(:template, :enabled, 1)
+        api.add_filter(:template, :id, id)
+      end
+    end
+  end
+end

--- a/lib/sendgrid/template_mailer.rb
+++ b/lib/sendgrid/template_mailer.rb
@@ -1,0 +1,63 @@
+require_relative './recipient'
+require_relative './template'
+require_relative './mail'
+
+module SendGrid
+  class InvalidClient < StandardError; end
+  class InvalidTemplate < StandardError; end
+  class InvalidRecipients < StandardError; end
+
+  class TemplateMailer
+
+    # This class is responsible for coordinating the responsibilities
+    #  of various models in the gem.
+    # It makes use of the Recipient, Template and Mail models to create
+    #  a single work flow, an example might look like:
+    #
+    # users = User.where(email: ['first@gmail.com', 'second@gmail.com'])
+    #
+    # recipients = []
+    #
+    # users.each do |user|
+    #   recipient = SendGrid::Recipient.new(user.email)
+    #   recipient.add_substitution('first_name', user.first_name)
+    #   recipient.add_substitution('city', user.city)
+    #
+    #   recipients << recipient
+    # end
+    #
+    # template = SendGrid::Template.new('MY_TEMPLATE_ID')
+    #
+    # client = SendGrid::Client.new(api_user: my_user, api_key: my_key)
+    #
+    # mail_defaults = {
+    #   from: 'admin@email.com',
+    #   html: '<h1>I like email</h1>',
+    #   text: 'I like email'
+    #   subject: 'Email is great',
+    # }
+    #
+    # mailer = TemplateMailer.new(client, template, recipients)
+    # mailer.mail(mail_defaults)
+    def initialize(client, template, recipients = [])
+      @client = client
+      @template = template
+      @recipients = recipients
+
+      raise InvalidClient, 'Client must be present' if @client.nil?
+      raise InvalidTemplate, 'Template must be present' if @template.nil?
+      raise InvalidRecipients, 'Recipients may not be empty' if @recipients.empty?
+
+      @recipients.each do |recipient|
+        @template.add_recipient(recipient)
+      end
+    end
+
+    def mail(params = {})
+      mail = Mail.new(params)
+
+      mail.template = @template
+      @client.send(mail.to_h)
+    end
+  end
+end

--- a/spec/lib/sendgrid/client_spec.rb
+++ b/spec/lib/sendgrid/client_spec.rb
@@ -1,0 +1,160 @@
+require_relative '../../../lib/sendgrid-ruby'
+
+module SendGrid
+  describe Client do
+    describe '#initialize' do
+      let(:params) do
+        {
+          api_user: api_user,
+          api_key: api_key,
+          host: host,
+          endpoint: endpoint,
+          conn: conn,
+          user_agent: user_agent,
+        }.reject { |_, v| v.nil? }
+      end
+
+      let(:api_user) { anything }
+      let(:api_key) { anything }
+      let(:host) { anything }
+      let(:endpoint) { anything }
+      let(:conn) { anything }
+      let(:user_agent) { anything }
+
+      subject { described_class.new(params) }
+
+      context 'all required parameters are present' do
+        it 'sets instance variables' do
+          expect(subject.instance_variable_get(:@api_user)).to_not be_nil
+          expect(subject.instance_variable_get(:@api_key)).to_not be_nil
+          expect(subject.instance_variable_get(:@host)).to_not be_nil
+          expect(subject.instance_variable_get(:@endpoint)).to_not be_nil
+          expect(subject.instance_variable_get(:@conn)).to_not be_nil
+          expect(subject.instance_variable_get(:@user_agent)).to_not be_nil
+        end
+      end
+
+      context 'conn is nil' do
+        let(:conn) { nil }
+
+        it 'calls out to establish one' do
+          expect_any_instance_of(described_class).to receive(:create_conn).once
+          subject
+        end
+      end
+
+      context 'host is nil' do
+        let(:host) { nil }
+
+        it 'sets the host to a default' do
+          expect(subject.instance_variable_get(:@host)).to eq('https://api.sendgrid.com')
+        end
+      end
+
+      context 'endpoint is nil' do
+        let(:endpoint) { nil }
+
+        it 'sets the host to a default' do
+          expect(subject.instance_variable_get(:@endpoint)).to eq('/api/mail.send.json')
+        end
+      end
+
+      context 'user_agent is nil' do
+        let(:user_agent) { nil }
+
+        it 'sets the host to a default' do
+          expect(subject.instance_variable_get(:@user_agent)).to eq('sendgrid/' + SendGrid::VERSION + ';ruby')
+        end
+      end
+
+      context 'api_key or api_user is nil' do
+        context 'api_key is nil' do
+          let(:api_key) { nil }
+
+          it { expect { subject }.to raise_error(SendGrid::Exception, 'api_user and api_key are required') }
+        end
+
+        context 'api_user is nil' do
+          let(:api_user) { nil }
+
+          it { expect { subject }.to raise_error(SendGrid::Exception, 'api_user and api_key are required') }
+        end
+
+        context 'both are nil' do
+          let(:api_key) { nil }
+          let(:api_user) { nil }
+
+          it { expect { subject }.to raise_error(SendGrid::Exception, 'api_user and api_key are required') }
+        end
+      end
+
+      context 'a block is given' do
+        it 'yields' do
+          expect { |b| described_class.new(params, &b) }.to yield_control
+        end
+      end
+    end
+
+    describe '#send' do
+      let(:api_key) { anything }
+      let(:api_user) { anything }
+
+      subject { described_class.new(api_key: api_key, api_user: api_user) }
+
+      let(:mail) { Mail.new }
+      let(:mail_hash) { {} }
+
+      before do
+        allow(mail).to receive(:to_h) { mail_hash }
+      end
+
+      it 'merges api_user and api_key into the mail hash' do
+        allow_any_instance_of(RestClient::Resource).to receive(:post)
+
+        expect(mail_hash).to receive(:merge).with({ api_key: api_key, api_user: api_user })
+        subject.send(mail)
+      end
+
+      it 'calls out to RestClient::Resource' do
+        payload = mail_hash.merge(api_user: api_user, api_key: api_key)
+        expect_any_instance_of(RestClient::Resource).to receive(:post).with(payload, hash_including(:user_agent))
+        subject.send(mail)
+      end
+
+      describe 'responses' do
+        let(:response) { Object.new }
+        let(:request) { anything }
+        let(:result) { anything }
+
+        before do
+          allow(response).to receive(:code) { response_code }
+          allow_any_instance_of(RestClient::Resource).to receive(:post).and_yield(response, request, result)
+        end
+
+        context '200 response' do
+          let(:response_code) { 200 }
+
+          it 'returns the response' do
+            expect(subject.send(mail)).to eq(response)
+          end
+        end
+
+        context '400 response' do
+          let(:response_code) { 400 }
+
+          it 'creates a new exception' do
+            expect { subject.send(mail) }.to raise_error(SendGrid::Exception)
+          end
+        end
+
+        context '500 response' do
+          let(:response_code) { 500 }
+
+          it 'creates a new exception' do
+            expect { subject.send(mail) }.to raise_error(SendGrid::Exception)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/sendgrid/mail_spec.rb
+++ b/spec/lib/sendgrid/mail_spec.rb
@@ -240,27 +240,6 @@ module SendGrid
       end
     end
 
-    describe '!#template' do
-      let(:template_id) { anything }
-
-      subject { described_class.new(api_user: anything, api_key: anything, template_id: template_id) }
-
-      context 'template_id is set' do
-        it 'initializes and returns a template' do
-          expect(Template).to receive(:new).with(template_id).and_call_original
-          expect(subject.send(:template)).to be_a(Template)
-        end
-      end
-
-      context 'template_id is not set' do
-        let(:template_id) { nil }
-
-        it 'returns nil' do
-          expect(subject.send(:template)).to be_nil
-        end
-      end
-    end
-
     describe '!#smtpapi_json' do
       let(:smtpapi) { Smtpapi::Header.new }
 
@@ -271,9 +250,9 @@ module SendGrid
         subject.send(:smtpapi_json)
       end
 
-      context 'a template id has been set' do
+      context 'a template is present' do
         before do
-          subject.template_id = anything
+          subject.template = Template.new(anything)
         end
 
         it 'calls the add_to_smtpapi on the template' do

--- a/spec/lib/sendgrid/mail_spec.rb
+++ b/spec/lib/sendgrid/mail_spec.rb
@@ -1,0 +1,236 @@
+require_relative '../../../lib/sendgrid/mail'
+
+module SendGrid
+  describe Mail do
+    describe '#initialize' do
+      let(:params) do
+        {
+          to: anything,
+          to_name: anything,
+          from: anything,
+          from_name: anything,
+          subject: anything,
+          text: anything,
+          html: anything,
+          cc: anything,
+          bcc: anything,
+          reply_to: anything,
+          date: anything,
+          smtpapi: anything,
+          attachments: anything,
+        }
+      end
+
+      subject { described_class.new(params) }
+
+      it 'sets instance variables' do
+        expect(subject.instance_variable_get(:@to)).to_not be_nil
+        expect(subject.instance_variable_get(:@to_name)).to_not be_nil
+        expect(subject.instance_variable_get(:@from)).to_not be_nil
+        expect(subject.instance_variable_get(:@from_name)).to_not be_nil
+        expect(subject.instance_variable_get(:@subject)).to_not be_nil
+        expect(subject.instance_variable_get(:@text)).to_not be_nil
+        expect(subject.instance_variable_get(:@html)).to_not be_nil
+        expect(subject.instance_variable_get(:@cc)).to_not be_nil
+        expect(subject.instance_variable_get(:@bcc)).to_not be_nil
+        expect(subject.instance_variable_get(:@reply_to)).to_not be_nil
+        expect(subject.instance_variable_get(:@date)).to_not be_nil
+        expect(subject.instance_variable_get(:@smtpapi)).to_not be_nil
+        expect(subject.instance_variable_get(:@attachments)).to_not be_nil
+        expect(subject.instance_variable_get(:@headers)).to_not be_nil
+      end
+
+      describe 'headers' do
+        context 'they are passed in' do
+          subject { described_class.new(params.merge(headers: { foo: :bar })) }
+
+          it 'does not initalize with an empty hash' do
+            instance_headers = subject.instance_variable_get(:@headers)
+            expect(instance_headers).to_not eq({})
+          end
+        end
+
+        context 'they are not passed in' do
+          it 'initializes an empty hash' do
+            instance_headers = subject.instance_variable_get(:@headers)
+            expect(instance_headers).to eq({})
+          end
+        end
+      end
+
+      describe 'attachments' do
+        context 'they are passed in' do
+          subject { described_class.new(params.merge(attachments: { foo: :bar })) }
+
+          it 'does not initalize with an empty hash' do
+            instance_attachments = subject.instance_variable_get(:@attachments)
+            expect(instance_attachments).to_not eq({})
+          end
+        end
+
+        context 'they are not passed in' do
+          it 'initializes an empty hash' do
+            instance_attachments = subject.instance_variable_get(:@attachments)
+            expect(instance_attachments).to eq(anything)
+          end
+        end
+      end
+
+      describe 'smtpapi' do
+        context 'a smtpapi was passed in' do
+          subject { described_class.new(params.merge(smtpapi: Object.new)) }
+
+          it 'does not initalize with a new object' do
+            instance_smtpapi = subject.instance_variable_get(:@smtpapi)
+            expect(instance_smtpapi).to_not be_a(Smtpapi::Header)
+          end
+        end
+
+        context 'a smtpapi was not passed in' do
+          subject { described_class.new(params.reject { |k, _| k == :smtpapi } ) }
+
+          it 'initializes a new Smtpapi::Header object' do
+            instance_smtpapi = subject.instance_variable_get(:@smtpapi)
+            expect(instance_smtpapi).to be_a(Smtpapi::Header)
+          end
+        end
+      end
+
+      context 'a block is given' do
+        it 'yields to the block' do
+          expect { |b| described_class.new(params, &b) }.to yield_control
+        end
+      end
+    end
+
+    describe '#add_to' do
+      let(:to_email) { 'anything@example.com' }
+
+      it 'calls add_to on the smtpapi' do
+        expect_any_instance_of(Smtpapi::Header).to receive(:add_to).with(to_email)
+        subject.add_to(to_email)
+      end
+    end
+
+    describe '#add_attachment' do
+      let(:attachment_path) { '/some/file/path' }
+
+      before do
+        allow(File).to receive(:new).with(attachment_path) { anything }
+        allow(File).to receive(:basename) { anything }
+      end
+
+      it 'adds the file to the attachments list' do
+        expect do
+          subject.add_attachment(attachment_path)
+        end.to change { subject.attachments }
+      end
+    end
+
+    describe '#to_h' do
+      let(:attachments) { [{ name: 'some filename', file: anything }] }
+      let(:params) do
+        {
+          to: anything,
+          to_name: anything,
+          from: anything,
+          from_name: anything,
+          subject: anything,
+          text: anything,
+          html: anything,
+          cc: anything,
+          bcc: anything,
+          reply_to: anything,
+          date: anything,
+          smtpapi: anything,
+          attachments: attachments,
+        }
+      end
+
+      subject { described_class.new(params) }
+
+      context 'with all fields populated' do
+        it 'returns all fields in the response' do
+          payload = subject.to_h
+          expect(payload).to have_key(:from)
+          expect(payload).to have_key(:fromname)
+          expect(payload).to have_key(:subject)
+          expect(payload).to have_key(:to)
+          expect(payload).to have_key(:toname)
+          expect(payload).to have_key(:date)
+          expect(payload).to have_key(:replyto)
+          expect(payload).to have_key(:cc)
+          expect(payload).to have_key(:bcc)
+          expect(payload).to have_key(:text)
+          expect(payload).to have_key(:html)
+          expect(payload).to have_key(:'x-smtpapi')
+          expect(payload).to have_key(:files)
+        end
+      end
+
+      context 'with nil fields' do
+        let(:params) do
+          {
+            to: anything,
+            to_name: anything,
+            from: anything,
+            from_name: anything,
+            subject: anything,
+            text: anything,
+            html: anything,
+            reply_to: anything,
+            date: anything,
+            smtpapi: anything,
+            attachments: attachments,
+          }
+        end
+
+        it 'does not include them in the response' do
+          payload = subject.to_h
+          expect(payload).to have_key(:from)
+          expect(payload).to have_key(:fromname)
+          expect(payload).to have_key(:subject)
+          expect(payload).to have_key(:to)
+          expect(payload).to have_key(:toname)
+          expect(payload).to have_key(:date)
+          expect(payload).to have_key(:replyto)
+          expect(payload).to_not have_key(:cc)
+          expect(payload).to_not have_key(:bcc)
+          expect(payload).to have_key(:text)
+          expect(payload).to have_key(:html)
+          expect(payload).to have_key(:'x-smtpapi')
+          expect(payload).to have_key(:files)
+        end
+      end
+
+      describe 'attachments' do
+        it 'restructures the hash to sit under a files key' do
+          payload = subject.to_h
+          expect(payload[:files]).to eq(attachments.first[:name] => attachments.first[:file])
+        end
+
+        context 'attachments is an empty array' do
+          let(:attachments) { [] }
+          it 'does not include files' do
+            expect(subject.to_h).to_not have_key(:files)
+          end
+        end
+      end
+
+      describe 'to' do
+        context 'the to is nil and the smtpapi to is not nil' do
+          before do
+            allow_any_instance_of(Smtpapi::Header).to receive(:to) { [anything] }
+          end
+
+          subject { described_class.new(params.reject { |k, _| k == :to || k == :smtpapi }) }
+
+          it 'sets the to address to from' do
+            payload = subject.to_h
+            expect(payload[:to]).to eq(params[:from])
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/sendgrid/mail_spec.rb
+++ b/spec/lib/sendgrid/mail_spec.rb
@@ -231,6 +231,56 @@ module SendGrid
           end
         end
       end
+
+      describe 'x-smtpapi' do
+        it 'calls the helper method for the smtpapi' do
+          expect(subject).to receive(:smtpapi_json)
+          subject.to_h
+        end
+      end
+    end
+
+    describe '!#template' do
+      let(:template_id) { anything }
+
+      subject { described_class.new(api_user: anything, api_key: anything, template_id: template_id) }
+
+      context 'template_id is set' do
+        it 'initializes and returns a template' do
+          expect(Template).to receive(:new).with(template_id).and_call_original
+          expect(subject.send(:template)).to be_a(Template)
+        end
+      end
+
+      context 'template_id is not set' do
+        let(:template_id) { nil }
+
+        it 'returns nil' do
+          expect(subject.send(:template)).to be_nil
+        end
+      end
+    end
+
+    describe '!#smtpapi_json' do
+      let(:smtpapi) { Smtpapi::Header.new }
+
+      subject { described_class.new(smtpapi: smtpapi, api_user: anything, api_key: anything)}
+
+      it 'calls the to_json method on smtpapi' do
+        expect(smtpapi).to receive(:to_json)
+        subject.send(:smtpapi_json)
+      end
+
+      context 'a template id has been set' do
+        before do
+          subject.template_id = anything
+        end
+
+        it 'calls the add_to_smtpapi on the template' do
+          expect(subject.send(:template)).to receive(:add_to_smtpapi).with(smtpapi)
+          subject.send(:smtpapi_json)
+        end
+      end
     end
   end
 end

--- a/spec/lib/sendgrid/recipient_spec.rb
+++ b/spec/lib/sendgrid/recipient_spec.rb
@@ -1,0 +1,93 @@
+require_relative '../../../lib/sendgrid/recipient'
+
+module SendGrid
+  describe Recipient do
+    subject { described_class.new(anything) }
+
+    describe '#initialize' do
+      it 'sets the address instance var' do
+        expect(subject.instance_variable_get(:@address)).to_not be_nil
+      end
+
+      it 'sets substitutions to an empty hash' do
+        expect(subject.instance_variable_get(:@substitutions)).to eq({})
+      end
+    end
+
+    describe '#add_substitution' do
+      it 'adds the key and value to the substitutions hash' do
+        subject.add_substitution(:foo, :bar)
+        expect(subject.substitutions).to have_key(:foo)
+        expect(subject.substitutions[:foo]).to eq(:bar)
+      end
+
+      context 'the same substiution key already exists' do
+        before do
+          subject.add_substitution(:foo, :bar)
+        end
+
+        it 'replaces the value' do
+          subject.add_substitution(:foo, :baz)
+          expect(subject.substitutions).to have_key(:foo)
+          expect(subject.substitutions[:foo]).to eq(:baz)
+        end
+      end
+    end
+
+    describe '#add_to_smtpapi' do
+      let(:substitutions) { { foo: :bar, baz: :qux } }
+      let(:smtp_api) { Smtpapi::Header.new }
+      before do
+        substitutions.each do |key, value|
+          subject.add_substitution(key, value)
+        end
+      end
+
+      it 'adds the address' do
+        expect(smtp_api).to receive(:add_to)
+        subject.add_to_smtpapi(smtp_api)
+      end
+
+      it 'calls add_substitution as many times as there are substitution keys' do
+        substitutions.each do |key, value|
+          expect(smtp_api).to receive(:add_substitution).with(key, value)
+        end
+
+        subject.add_to_smtpapi(smtp_api)
+      end
+
+      context 'address is nil and/or substitutions is empty' do
+        subject { described_class.new(address) }
+        let(:address) { anything }
+
+        context 'address is nil' do
+          let(:address) { nil }
+
+          it 'does nothing' do
+            expect(smtp_api).to_not receive(:add_substitution)
+            subject.add_to_smtpapi(smtp_api)
+          end
+        end
+
+        context 'substitutions is empty' do
+          let(:substitutions) { {} }
+
+          it 'does nothing' do
+            expect(smtp_api).to_not receive(:add_substitution)
+            subject.add_to_smtpapi(smtp_api)
+          end
+        end
+
+        context 'both are nil/empty' do
+          let(:substitutions) { {} }
+          let(:address) { nil }
+
+          it 'does nothing' do
+            expect(smtp_api).to_not receive(:add_substitution)
+            subject.add_to_smtpapi(smtp_api)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/sendgrid/recipient_spec.rb
+++ b/spec/lib/sendgrid/recipient_spec.rb
@@ -58,7 +58,7 @@ module SendGrid
 
       it 'calls add_substitution as many times as there are substitution keys' do
         substitutions.each do |key, value|
-          expect(smtp_api).to receive(:add_substitution).with(key, value)
+          expect(smtp_api).to receive(:add_substitution).with(key, [value])
         end
 
         subject.add_to_smtpapi(smtp_api)

--- a/spec/lib/sendgrid/recipient_spec.rb
+++ b/spec/lib/sendgrid/recipient_spec.rb
@@ -64,6 +64,20 @@ module SendGrid
         subject.add_to_smtpapi(smtp_api)
       end
 
+      context 'a substitution for the same key already exists' do
+        let(:substitutions) { { foo: :bar } }
+        let(:added_value) { [:bar, :rab] }
+
+        before do
+          smtp_api.add_substitution(:foo, [:rab])
+        end
+
+        it 'adds to it' do
+          expect(smtp_api).to receive(:add_substitution).with(:foo, array_including(added_value))
+          subject.add_to_smtpapi(smtp_api)
+        end
+      end
+
       context 'substitutions is empty' do
         let(:substitutions) { {} }
 

--- a/spec/lib/sendgrid/recipient_spec.rb
+++ b/spec/lib/sendgrid/recipient_spec.rb
@@ -12,6 +12,14 @@ module SendGrid
       it 'sets substitutions to an empty hash' do
         expect(subject.instance_variable_get(:@substitutions)).to eq({})
       end
+
+      context 'initialized with nil' do
+        it 'raises an error' do
+          expect do
+            described_class.new(nil)
+          end.to raise_error(Recipient::NoAddress, 'Recipient address cannot be nil')
+        end
+      end
     end
 
     describe '#add_substitution' do
@@ -56,36 +64,12 @@ module SendGrid
         subject.add_to_smtpapi(smtp_api)
       end
 
-      context 'address is nil and/or substitutions is empty' do
-        subject { described_class.new(address) }
-        let(:address) { anything }
+      context 'substitutions is empty' do
+        let(:substitutions) { {} }
 
-        context 'address is nil' do
-          let(:address) { nil }
-
-          it 'does nothing' do
-            expect(smtp_api).to_not receive(:add_substitution)
-            subject.add_to_smtpapi(smtp_api)
-          end
-        end
-
-        context 'substitutions is empty' do
-          let(:substitutions) { {} }
-
-          it 'does nothing' do
-            expect(smtp_api).to_not receive(:add_substitution)
-            subject.add_to_smtpapi(smtp_api)
-          end
-        end
-
-        context 'both are nil/empty' do
-          let(:substitutions) { {} }
-          let(:address) { nil }
-
-          it 'does nothing' do
-            expect(smtp_api).to_not receive(:add_substitution)
-            subject.add_to_smtpapi(smtp_api)
-          end
+        it 'does nothing' do
+          expect(smtp_api).to_not receive(:add_substitution)
+          subject.add_to_smtpapi(smtp_api)
         end
       end
     end

--- a/spec/lib/sendgrid/template_mailer_spec.rb
+++ b/spec/lib/sendgrid/template_mailer_spec.rb
@@ -1,0 +1,86 @@
+require_relative '../../../lib/sendgrid/template_mailer'
+
+module SendGrid
+  describe TemplateMailer do
+    let(:client) { anything }
+    let(:template) { Template.new(anything) }
+    let(:recipients) { [Recipient.new(anything)] }
+
+    describe '#initialize' do
+      let(:client) { anything }
+      let(:template) { Template.new(anything) }
+      let(:recipients) { [anything] }
+
+      subject { described_class.new(client, template, recipients) }
+
+      it 'sets the instance variables' do
+        expect(subject.instance_variable_get(:@client)).to_not be_nil
+        expect(subject.instance_variable_get(:@template)).to_not be_nil
+        expect(subject.instance_variable_get(:@recipients)).to_not be_nil
+      end
+
+      context 'nil variables' do
+        context 'template is nil' do
+          let(:template) { nil }
+
+          it 'raises error' do
+            expect do
+              subject
+            end.to raise_error(InvalidTemplate, 'Template must be present')
+          end
+        end
+
+        context 'client is nil' do
+          let(:client) { nil }
+
+          it 'raises error' do
+            expect do
+              subject
+            end.to raise_error(InvalidClient, 'Client must be present')
+          end
+        end
+      end
+
+      context 'recipients' do
+        let(:first_recipient) { Recipient.new('someone@anything.com') }
+        let(:second_recipient) { Recipient.new('test@test.com') }
+        let(:recipients) { [first_recipient, second_recipient] }
+
+        it 'adds them to the template' do
+          expect(template).to receive(:add_recipient).with(first_recipient)
+          expect(template).to receive(:add_recipient).with(second_recipient)
+
+          subject
+        end
+      end
+    end
+
+    describe '#mail' do
+      subject { described_class.new(client, template, recipients) }
+
+      let(:mail_params) { {} }
+      let(:mail_to_h) { '' }
+
+      before do
+        allow(subject).to receive(:mail_params) { mail_params }
+        allow_any_instance_of(Mail).to receive(:to_h) { mail_to_h }
+        allow(client).to receive(:send)
+      end
+
+      it 'creates a new mail object' do
+        expect(Mail).to receive(:new).with(mail_params).and_call_original
+        subject.mail
+      end
+
+      it 'adds the template to the mail object' do
+        expect_any_instance_of(Mail).to receive(:template=).with(template)
+        subject.mail
+      end
+
+      it 'calls send on the client with the mail object' do
+        expect(client).to receive(:send).with(mail_to_h)
+        subject.mail
+      end
+    end
+  end
+end

--- a/spec/lib/sendgrid/template_spec.rb
+++ b/spec/lib/sendgrid/template_spec.rb
@@ -1,0 +1,33 @@
+require_relative '../../../lib/sendgrid/template'
+
+module SendGrid
+  describe Template do
+    let(:id) { anything }
+    subject { described_class.new(id) }
+
+    describe '#initialize' do
+      it 'sets the id instance var' do
+        expect(subject.instance_variable_get(:@id)).to_not be_nil
+      end
+    end
+
+    describe '#add_to_smtpapi' do
+      let(:id) { rand(8999) }
+      let(:smtpapi) { Smtpapi::Header.new }
+
+      it 'adds enabled and the templates id' do
+        expect(smtpapi).to receive(:add_filter).with(:template, :enabled, 1)
+        expect(smtpapi).to receive(:add_filter).with(:template, :id, id)
+        subject.add_to_smtpapi(smtpapi)
+      end
+
+      context 'smtpapi is nil' do
+        it 'does not error' do
+          expect do
+            subject.add_to_smtpapi(nil)
+          end.to_not raise_error
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/sendgrid/template_spec.rb
+++ b/spec/lib/sendgrid/template_spec.rb
@@ -16,8 +16,8 @@ module SendGrid
       let(:smtpapi) { Smtpapi::Header.new }
 
       it 'adds enabled and the templates id' do
-        expect(smtpapi).to receive(:add_filter).with(:template, :enabled, 1)
-        expect(smtpapi).to receive(:add_filter).with(:template, :id, id)
+        expect(smtpapi).to receive(:add_filter).with(:templates, :enable, 1)
+        expect(smtpapi).to receive(:add_filter).with(:templates, :template_id, id)
         subject.add_to_smtpapi(smtpapi)
       end
 

--- a/spec/lib/sendgrid/template_spec.rb
+++ b/spec/lib/sendgrid/template_spec.rb
@@ -28,6 +28,34 @@ module SendGrid
           end.to_not raise_error
         end
       end
+
+      context 'with recipients' do
+        let(:substitution_key) { :foo }
+        let(:substitution_value) { :bar }
+        let(:recipients) do
+          [].tap do |recipients|
+            3.times.each do
+              r = Recipient.new("test+#{ rand(100) }@example.com")
+              r.add_substitution(substitution_key, substitution_value)
+              recipients << r
+            end
+          end
+        end
+
+        before do
+          recipients.each do |r|
+            subject.add_recipient(r)
+          end
+        end
+
+        it 'calls the recipients call to add to smtpapi' do
+          recipients.each do |recipient|
+            expect(recipient).to receive(:add_to_smtpapi).with(smtpapi)
+          end
+
+          subject.add_to_smtpapi(smtpapi)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
@rbin and anyone else at SendGrid

1. Wrote RSpec 3 compatible spec suite
2. Added Travis integration for Continuous Integration
3. README updated to remove Eddie Zane (He informed me he has left SendGrid)
4. POROs introduced to ease with Template Calling
   * `Recipient`
     - Responsible for holding user data and optionally keeping track
      of template substitutions.
     - Has ability to add itself to an `SMTPAPI` 
   * `Template`
     - Responsible for keeping track of `template_id` and managing `Recipients`
     - Has ability to add itself to an `SMTPAPI` 
   * `TemplateMailer`
     - Responsible for composing requests given a `Template` and 1 to many `Recipients`
     - Handles common error cases
     - Invokes the existing `Mail` and `Client` objects to handle actual delivery