### PR TITLE
Remove puts from mail.rb

### DIFF
--- a/lib/sendgrid/mail.rb
+++ b/lib/sendgrid/mail.rb
@@ -164,9 +164,6 @@ module SendGrid
         end
       end
       
-      puts payload[:files]
-      puts payload[:content]
-      
       payload
     end
     # rubocop:enable Style/HashSyntax


### PR DESCRIPTION
Remove two puts method-calls from mail.rb
This affects the output of the unit tests of my project.