### PR TITLE
Add cache_recipients option to SendGrid::Template.new (Issue #41)

### DIFF
--- a/lib/sendgrid/template.rb
+++ b/lib/sendgrid/template.rb
@@ -2,14 +2,16 @@ require 'smtpapi'
 
 module SendGrid
   class Template
-    attr_reader :id, :recipients
+    attr_reader :id, :recipients, :cache_recipients
 
-    def initialize(id)
+    def initialize(id, opts = {})
       @id = id
       @recipients = []
+      @cache_recipients = opts.fetch(:cache_recipients, true)
     end
 
     def add_recipient(recipient)
+      @recipients = [] unless cache_recipients
       recipients << recipient
     end
 

--- a/lib/sendgrid/version.rb
+++ b/lib/sendgrid/version.rb
@@ -1,3 +1,3 @@
 module SendGrid
-  VERSION = '1.1.6'
+  VERSION = '1.1.7'
 end

--- a/lib/sendgrid/version.rb
+++ b/lib/sendgrid/version.rb
@@ -1,3 +1,3 @@
 module SendGrid
-  VERSION = '1.1.7'
+  VERSION = '1.1.6'
 end

--- a/spec/lib/sendgrid/template_spec.rb
+++ b/spec/lib/sendgrid/template_spec.rb
@@ -9,6 +9,40 @@ module SendGrid
       it 'sets the id instance var' do
         expect(subject.instance_variable_get(:@id)).to_not be_nil
       end
+      it 'cache_recipients instance variable defaults to true' do
+        expect(subject.instance_variable_get(:@cache_recipients)).to be_truthy
+      end
+      context 'cache_recipients: false' do
+        subject { described_class.new(id, cache_recipients: false) }
+
+        it 'sets cache_recipients instance varialbe to false' do
+          expect(subject.instance_variable_get(:@cache_recipients)).to be_falsey
+        end
+      end
+    end
+
+    describe '#add_recipient' do
+      let(:first_recipient) { Recipient.new('someone@anything.com') }
+      let(:second_recipient) { Recipient.new('test@test.com') }
+      let(:recipients) { [first_recipient, second_recipient] }
+
+      context 'cache_recipients: true' do
+        it 'caches the added recipients' do
+          subject.add_recipient(first_recipient)
+          subject.add_recipient(second_recipient)
+          expect(subject.recipients).to match_array(recipients)
+        end
+      end
+
+      context 'cache_recipients: false' do
+        subject { described_class.new(id, cache_recipients: false) }
+
+        it 'does not cache the added recipients' do
+          subject.add_recipient(first_recipient)
+          subject.add_recipient(second_recipient)
+          expect(subject.recipients).to match_array([second_recipient])
+        end
+      end
     end
 
     describe '#add_to_smtpapi' do


### PR DESCRIPTION
Adds an option to clear SendGrid::Template.recipients on each
SendGrid::Template#add_recipient call. The default behaviour has not
been changed as the cache_recipients option defaults to true.