### PR TITLE
Remove default attachment when there is only inline-content

### DIFF
--- a/lib/sendgrid/mail.rb
+++ b/lib/sendgrid/mail.rb
@@ -175,6 +175,12 @@ module SendGrid
         end
       end
 
+      if attachments.empty? and !contents.empty?
+        if payload[:files].has_key?(":default")
+          payload[:files].delete(":default")
+        end
+      end
+
       payload
     end
     # rubocop:enable Style/HashSyntax


### PR DESCRIPTION
when there is only inline-content but no attachment assigned, there is always an default attachment, which is useless(and annoying).
So I removed the default attachment in this scenario.