### PR TITLE
Clean up dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,2 @@
-gem 'dotenv-rails'
-gem 'smtpapi'
-gem 'rest-client'
 source 'https://rubygems.org'
 gemspec

--- a/sendgrid-ruby.gemspec
+++ b/sendgrid-ruby.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'smtpapi', '~> 0.1'
   spec.add_dependency 'faraday', '~> 0.9'
   spec.add_dependency 'mimemagic'
+  spec.add_development_dependency 'dotenv'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec'
   spec.add_development_dependency 'rspec-nc'


### PR DESCRIPTION
Hello SendGrid!

I noticed a few oddities with the dependencies in this gem.

- The Gemfile is depending on `dotenv-rails`, but it looks like it is sufficient to only include `dotenv`
- The `smtpapi` gem is already a dependency in the gemspec, so including it in the Gemfile is redundant
- It appears the `rest-client` gem is unused

This PR cleans these things up.