### PR TITLE
Bug fix for TemplateMailer

### DIFF
--- a/lib/sendgrid/template_mailer.rb
+++ b/lib/sendgrid/template_mailer.rb
@@ -53,7 +53,7 @@ module SendGrid
       mail = Mail.new(params)
 
       mail.template = @template
-      @client.send(mail.to_h)
+      @client.send(mail)
     end
   end
 end

--- a/spec/lib/sendgrid/template_mailer_spec.rb
+++ b/spec/lib/sendgrid/template_mailer_spec.rb
@@ -78,7 +78,7 @@ module SendGrid
       end
 
       it 'calls send on the client with the mail object' do
-        expect(client).to receive(:send).with(mail_to_h)
+        expect(client).to receive(:send).with(instance_of(Mail))
         subject.mail
       end
     end


### PR DESCRIPTION
@thinkingserious 
Pointed out to me in a stack overflow answer: http://stackoverflow.com/questions/33991685/sendgrid-ruby-library-send-context-specific-values-in-transactional-emails/33992885?noredirect=1#comment60175742_33992885

During a large refactoring when this code was being written, the TemplateMailer
  was passing a hash to the client instead of an object.