### PR TITLE
Automate StopLight.io Prism mock server locally & on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,11 @@
 language: ruby
 rvm:
 - 2.2
+before_script:
+- mkdir prism
+- mkdir prism/bin
+- export PATH=$PATH:$PWD/prism/bin/
+- ./test/prism.sh
 notifications:
   hipchat:
     rooms:

--- a/test/prism.sh
+++ b/test/prism.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+install () {
+
+set -eu
+
+UNAME=$(uname)
+ARCH=$(uname -m)
+if [ "$UNAME" != "Linux" ] && [ "$UNAME" != "Darwin" ] && [ "$ARCH" != "x86_64" ] && [ "$ARCH" != "i686" ]; then
+    echo "Sorry, OS/Architecture not supported: ${UNAME}/${ARCH}. Download binary from https://github.com/stoplightio/prism/releases"
+    exit 1
+fi
+
+if [ "$UNAME" = "Darwin" ] ; then
+  OSX_ARCH=$(uname -m)
+  if [ "${OSX_ARCH}" = "x86_64" ] ; then
+    PLATFORM="darwin_amd64"
+  fi
+elif [ "$UNAME" = "Linux" ] ; then
+  LINUX_ARCH=$(uname -m)
+  if [ "${LINUX_ARCH}" = "i686" ] ; then
+    PLATFORM="linux_386"
+  elif [ "${LINUX_ARCH}" = "x86_64" ] ; then
+    PLATFORM="linux_amd64"
+  fi
+fi
+
+#LATEST=$(curl -s https://api.github.com/repos/stoplightio/prism/tags | grep -Eo '"name":.*?[^\\]",'  | head -n 1 | sed 's/[," ]//g' | cut -d ':' -f 2)
+LATEST="v0.2.7"
+URL="https://github.com/stoplightio/prism/releases/download/$LATEST/prism_$PLATFORM"
+DEST=./prism/bin/prism
+
+if [ -z $LATEST ] ; then
+  echo "Error requesting. Download binary from ${URL}"
+  exit 1
+else
+  curl -L $URL -o $DEST
+  chmod +x $DEST
+fi
+}
+
+install

--- a/test/sendgrid/test_sendgrid-ruby.rb
+++ b/test/sendgrid/test_sendgrid-ruby.rb
@@ -4,6 +4,27 @@ require 'minitest/autorun'
 require 'minitest/unit'
 
 class TestAPI < MiniTest::Test
+
+    unless File.exists?('/usr/local/bin/prism') || File.exists?(File.join(Dir.pwd, 'prism/bin/prism'))
+      if RUBY_PLATFORM =~ /mswin|mingw/
+        puts 'Please download the Windows binary (https://github.com/stoplightio/prism/releases) and place it in your /usr/local/bin directory'
+      else
+        puts 'Installing Prism'
+        IO.popen(['curl', '-s', 'https://raw.githubusercontent.com/stoplightio/prism/master/install.sh']) do |io|
+          out = io.read
+          unless system(out)
+            puts "Error downloading the prism binary, you can try downloading directly here (https://github.com/stoplightio/prism/releases) and place in your /user/local/bin directory, #{out}"
+            exit
+          end
+        end
+      end
+    end
+
+    puts 'Activating Prism (~20 seconds)'
+    @@prism_pid = spawn('prism run --mock --list --spec https://raw.githubusercontent.com/sendgrid/sendgrid-oai/master/oai_stoplight.json', [:out, :err] => '/dev/null')
+    sleep(15)
+    puts 'Prism started'
+
     def setup
         if ENV['TRAVIS']
             host = ENV['MOCK_HOST']
@@ -11,6 +32,11 @@ class TestAPI < MiniTest::Test
             host = "http://localhost:4010"
         end
         @sg = SendGrid::API.new(api_key: "SENDGRID_API_KEY", host: host)
+    end
+
+    Minitest.after_run do
+      Process.kill('TERM', @@prism_pid)
+      puts 'Prism shut down'
     end
 
     def test_init


### PR DESCRIPTION
This change automates Prism mock server to run locally & on Travis CI before the test, & shut it down afterward according to some references provided in #109.

This should resolve #109 