### PR TITLE
Typo 'user' for 'usr'

### DIFF
--- a/test/sendgrid/test_sendgrid-ruby.rb
+++ b/test/sendgrid/test_sendgrid-ruby.rb
@@ -13,7 +13,7 @@ class TestAPI < MiniTest::Test
         IO.popen(['curl', '-s', 'https://raw.githubusercontent.com/stoplightio/prism/master/install.sh']) do |io|
           out = io.read
           unless system(out)
-            puts "Error downloading the prism binary, you can try downloading directly here (https://github.com/stoplightio/prism/releases) and place in your /user/local/bin directory, #{out}"
+            puts "Error downloading the prism binary, you can try downloading directly here (https://github.com/stoplightio/prism/releases) and place in your /usr/local/bin directory, #{out}"
             exit
           end
         end


### PR DESCRIPTION
As per Node.js / Python / PHP implementations.