### PR TITLE
set api_key to empty string

### DIFF
--- a/lib/sendgrid/client.rb
+++ b/lib/sendgrid/client.rb
@@ -14,7 +14,7 @@ module SendGrid
     #   - +version+ -> the version of the API you wish to access,
     #                  currently only "v3" is supported
     #
-    def initialize(api_key: nil, host: nil, request_headers: nil, version: nil)
+    def initialize(api_key: '', host: nil, request_headers: nil, version: nil)
       @api_key          = api_key
       @host             = host ? host : 'https://api.sendgrid.com'
       @version          = version ? version : 'v3'


### PR DESCRIPTION
# Description

When creating an API key for a Sendgrid subuser who does not have an API key, you currently have to initialise a new client with an empty API key. `SendGrid::API.new(api_key: '')`

This feels pretty wonky and unintuitive. It also results in a `NoMethodError: undefined method + for nil:NilClass` error which is not very descriptive. 

This change would remove the opportunity for a`NoMethodError`. I believe it will make the `SendGrid::API` interface a bit easier to work with as well. 