### PR TITLE
Fix markdown syntax to show image

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,5 +199,4 @@ sendgrid-ruby is guided and supported by the SendGrid [Developer Experience Team
 
 sendgrid-ruby is maintained and funded by SendGrid, Inc. The names and logos for sendgrid-ruby are trademarks of SendGrid, Inc.
 
-![SendGrid Logo]
-(https://uiux.s3.amazonaws.com/2016-logos/email-logo%402x.png)
+![SendGrid Logo](https://uiux.s3.amazonaws.com/2016-logos/email-logo%402x.png)


### PR DESCRIPTION
see: https://github.com/sendgrid/sendgrid-ruby#about

Before:
<img width="853" alt="2017-04-01 23 49 48" src="https://cloud.githubusercontent.com/assets/290782/24579749/02ab32ee-1736-11e7-8a01-fab25180d5a5.png">

After:
<img width="855" alt="2017-04-01 23 49 57" src="https://cloud.githubusercontent.com/assets/290782/24579750/05679f2c-1736-11e7-8f0c-c04b43babe5e.png">
