### PR TITLE
Add missing closing tag in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ puts response.headers
 - [How-to: Migration from v2 to v3](https://sendgrid.com/docs/Classroom/Send/v3_Mail_Send/how_to_migrate_from_v2_to_v3_mail_send.html)
 - [v3 Web API Mail Send Helper](https://github.com/sendgrid/sendgrid-python/tree/master/sendgrid/helpers/mail) - build a request object payload for a v3 /mail/send API call.
 
-<a name="use_cases">
+<a name="use_cases"></a>
 # Use Cases
 
 [Examples of common API use cases](https://github.com/sendgrid/sendgrid-ruby/blob/master/USE_CASES.md), such as how to send an email with a transactional template.


### PR DESCRIPTION
The missing closing tag breaks markup for header "Use Cases".

Before:
<img width="845" alt="2017-04-02 0 05 15" src="https://cloud.githubusercontent.com/assets/290782/24579830/2f53982a-1738-11e7-8b40-08a5e6f56dfa.png">

After:
<img width="839" alt="2017-04-02 0 05 29" src="https://cloud.githubusercontent.com/assets/290782/24579832/348deb88-1738-11e7-93a3-c3e9b5059d03.png">