### PR TITLE
Fixed problematic Sinatra dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: ruby
 rvm:
 - 2.2
+gemfile:
+- gemfiles/Sinatra_1.gemfile
+- gemfiles/Sinatra_2.gemfile
 before_script:
 - mkdir prism
 - mkdir prism/bin

--- a/gemfiles/Sinatra_1.gemfile
+++ b/gemfiles/Sinatra_1.gemfile
@@ -1,0 +1,6 @@
+source 'http://rubygems.org'
+
+gemspec path: '..'
+
+gem 'ruby_http_client'
+gem 'sinatra', '~> 1.4'

--- a/gemfiles/Sinatra_2.gemfile
+++ b/gemfiles/Sinatra_2.gemfile
@@ -1,0 +1,6 @@
+source 'http://rubygems.org'
+
+gemspec path: '..'
+
+gem 'ruby_http_client'
+gem 'sinatra', '>= 2.0.0.rc2'

--- a/sendgrid-ruby.gemspec
+++ b/sendgrid-ruby.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(/^(test|spec|features)/)
   spec.require_paths = ['lib']
   spec.add_dependency 'ruby_http_client', '~> 3.0'
-  spec.add_dependency 'sinatra', '2.0.0.rc2'
+  spec.add_dependency 'sinatra', '>= 1.4.7', '< 3'
   spec.add_development_dependency 'rake', '~> 0'
   spec.add_development_dependency 'rspec'
   spec.add_development_dependency 'pry'


### PR DESCRIPTION
Brings back Rails 4 compatibility (and Rack 1.x applications, in general), also removes release candidate version constraint (both broken in #160). Moreover, ensures that tests are run against two major Sinatra versions, which should protect from compatibility issues in future, somewhat.

Related issue: #159.