### PR TITLE
Substitute deprecated method

### DIFF
--- a/test/sendgrid/test_sendgrid-ruby.rb
+++ b/test/sendgrid/test_sendgrid-ruby.rb
@@ -5,7 +5,7 @@ require 'minitest/unit'
 
 class TestAPI < MiniTest::Test
 
-    unless File.exist?('/usr/local/bin/prism') || File.exists?(File.join(Dir.pwd, 'prism/bin/prism'))
+    unless File.exist?('/usr/local/bin/prism') || File.exist?(File.join(Dir.pwd, 'prism/bin/prism'))
       if RUBY_PLATFORM =~ /mswin|mingw/
         puts 'Please download the Windows binary (https://github.com/stoplightio/prism/releases) and place it in your /usr/local/bin directory'
       else


### PR DESCRIPTION
Substitute deprecated `File#exists?` with `File#exist?`. Fixes Ruby warning which was displayed in tests.