### PR TITLE
Fix add_attachment typo in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ All notable changes to this project will be documented in this file.
 - `personalization.custom_args` becomes `personalization.add_custom_arg()`
 - `mail.personalizations` becomes `mail.add_personalization()`
 - `mail.contents` becomes `mail.add_content()`
-- `mail.attachments` becomes `mail.attachment()`
+- `mail.attachments` becomes `mail.add_attachment()`
 - `mail.sections` becomes `mail.add_section()`
 - `mail.headers` becomes `mail.add_header()`
 - `mail.categories` becomes `mail.add_category()`


### PR DESCRIPTION
There was a typo in the version 5 change log.
`mail.attachment()`should be `mail.add_attachment()`