### PR TITLE
Convert key/value arguments to CustomArgs to strings

### DIFF
--- a/lib/sendgrid/helpers/mail/custom_arg.rb
+++ b/lib/sendgrid/helpers/mail/custom_arg.rb
@@ -4,7 +4,7 @@ module SendGrid
   class CustomArg
     def initialize(key: nil, value: nil)
       @custom_arg = {}
-      (key.nil? || value.nil?) ? @custom_arg = nil : @custom_arg[key] = value
+      (key.nil? || value.nil?) ? @custom_arg = nil : @custom_arg[key.to_s] = value.to_s
     end
 
     def custom_arg=(custom_arg)

--- a/test/sendgrid/helpers/mail/test_mail.rb
+++ b/test/sendgrid/helpers/mail/test_mail.rb
@@ -207,6 +207,21 @@ class TestMail < Minitest::Test
     assert_equal mail.to_json, expected_json
   end
 
+  def test_add_non_string_custom_arg
+    mail = Mail.new
+    mail.add_custom_arg(CustomArg.new(key: "Integer", value: 1))
+    mail.add_custom_arg(CustomArg.new(key: "Array", value: [1, "a", true]))
+    mail.add_custom_arg(CustomArg.new(key: "Hash", value: {"a" => 1, "b" => 2}))
+    expected_json = {
+        "custom_args"=>{
+                "Integer"=>"1",
+                "Array"=>"[1, \"a\", true]",
+                "Hash"=>"{\"a\"=>1, \"b\"=>2}",
+            }
+    }
+    assert_equal mail.to_json, expected_json
+  end
+
   def test_add_attachment
     mail = Mail.new
     mail.add_attachment('foo')


### PR DESCRIPTION
Sometimes the user can pass value argument in CustomArgs with a non string value. This commit will try to store whatever value comes in the form of a string.
This fixes #142