### PR TITLE
feat: Auto Generate Plain Text Content from HTML

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,5 @@ Gemfile.lock
 
 # unless supporting rvm < 1.11.0 or doing something fancy, ignore this:
 .rvmrc
+sendgrid.env
+sendgrid.env

--- a/Gemfile
+++ b/Gemfile
@@ -3,4 +3,4 @@ source 'http://rubygems.org'
 gemspec
 
 gem 'ruby_http_client'
-
+gem 'nokogiri'

--- a/gemfiles/Sinatra_1.gemfile
+++ b/gemfiles/Sinatra_1.gemfile
@@ -2,5 +2,6 @@ source 'http://rubygems.org'
 
 gemspec path: '..'
 
+gem 'nokogiri'
 gem 'ruby_http_client'
 gem 'sinatra', '~> 1.4'

--- a/gemfiles/Sinatra_2.gemfile
+++ b/gemfiles/Sinatra_2.gemfile
@@ -2,5 +2,6 @@ source 'http://rubygems.org'
 
 gemspec path: '..'
 
+gem 'nokogiri'
 gem 'ruby_http_client'
 gem 'sinatra', '>= 2.0.0.rc2'

--- a/lib/sendgrid/helpers/mail/mail.rb
+++ b/lib/sendgrid/helpers/mail/mail.rb
@@ -1,6 +1,9 @@
 # Build the request body for the v3/mail/send endpoint
 # Please see the examples/helpers/mail/example.rb for a demonstration of usage
 require 'json'
+require 'rubygems'
+require 'nokogiri'
+
 
 module SendGrid
   class Mail
@@ -168,5 +171,13 @@ module SendGrid
         'reply_to' => self.reply_to
       }.delete_if { |_, value| value.to_s.strip == '' || value == [] || value == {}}
     end
+
+    private
+      def generate_plain_text_content
+        if @contents.none? {|content| content['type'] == "text/plain"}
+          html = contents.first['value']
+          self.add_content(Content.new(type: 'text/plain', value: Nokogiri::HTML(html).text))
+        end
+      end
   end
 end

--- a/lib/sendgrid/helpers/mail/mail.rb
+++ b/lib/sendgrid/helpers/mail/mail.rb
@@ -1,8 +1,6 @@
 # Build the request body for the v3/mail/send endpoint
 # Please see the examples/helpers/mail/example.rb for a demonstration of usage
 require 'json'
-require 'rubygems'
-require 'nokogiri'
 
 
 module SendGrid

--- a/test/sendgrid/helpers/mail/test_mail.rb
+++ b/test/sendgrid/helpers/mail/test_mail.rb
@@ -150,6 +150,23 @@ class TestMail < Minitest::Test
     assert_equal(['foo'.to_json], mail.contents)
   end
 
+  def test_generate_plain_text_content
+    mail = Mail.new
+    mail.add_content(Content.new(type: 'text/html', value: '<html><body>some text here</body></html>'))
+    mail.send(:generate_plain_text_content)
+    expected_json = [
+        {
+            'type' => 'text/html',
+            'value' => '<html><body>some text here</body></html>'
+        },
+        {
+            'type' => 'text/plain',
+            'value' => 'some text here'
+        }
+    ].to_json
+    assert_equal mail.contents.to_json, expected_json
+  end
+
   def test_add_section
     mail = Mail.new
     mail.add_section(Section.new(key: '%section1%', value: 'Substitution Text for Section 1'))

--- a/test/sendgrid/helpers/mail/test_mail.rb
+++ b/test/sendgrid/helpers/mail/test_mail.rb
@@ -3,6 +3,7 @@ require_relative "../../../../lib/sendgrid/client"
 include SendGrid
 require "json"
 require 'minitest/autorun'
+require 'nokogiri'
 
 class TestMail < Minitest::Test
   def setup


### PR DESCRIPTION
Added private method to mail class to generate add to generate plain text (if not present) to self.contents, given content with type html using Nokogiri.
I added a simple test as well; feel free to request more. 

Also please point me towards the best place to call the generation method. Do we call it on send when only one content object is present in the contents array? Please clarify..

This should resolve #180 