### PR TITLE
Making README/Doc Sections More SEO Friendly

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,13 +2,13 @@ Hello! Thank you for choosing to help contribute to one of the SendGrid open sou
 
 - [CLAs and CCLAs](#cla)
 - [Roadmap & Milestones](#roadmap)
-- [Feature Request](#feature_request)
-- [Submit a Bug Report](#submit_a_bug_report)
-- [Improvements to the Codebase](#improvements_to_the_codebase)
-- [Understanding the Code Base](#understanding_the_codebase)
+- [Feature Request](#feature-request)
+- [Submit a Bug Report](#submit-a-bug-report)
+- [Improvements to the Codebase](#improvements-to-the-codebase)
+- [Understanding the Code Base](#understanding-the-codebase)
 - [Testing](#testing)
-- [Style Guidelines & Naming Conventions](#style_guidelines_and_naming_conventions)
-- [Creating a Pull Request](#creating_a_pull_request)
+- [Style Guidelines & Naming Conventions](#style-guidelines-and-naming-conventions)
+- [Creating a Pull Request](#creating-a-pull-request)
 
 <a name="roadmap"></a>
 We use [Milestones](https://github.com/sendgrid/sendgrid-ruby/milestones) to help define current roadmaps, please feel free to grab an issue from the current milestone. Please indicate that you have begun work on it to avoid collisions. Once a PR is made, community review, comments, suggestions and additional PRs are welcomed and encouraged.
@@ -26,7 +26,7 @@ When you create a Pull Request, after a few seconds, a comment will appear with 
 
 There are a few ways to contribute, which we'll enumerate below:
 
-<a name="feature_request"></a>
+<a name="feature-request"></a>
 ## Feature Request
 
 If you'd like to make a feature request, please read this section.
@@ -36,7 +36,7 @@ The GitHub issue tracker is the preferred channel for library feature requests, 
 - Please **search for existing issues** in order to ensure we don't have duplicate bugs/feature requests.
 - Please be respectful and considerate of others when commenting on issues
 
-<a name="submit_a_bug_report"></a>
+<a name="submit-a-bug-report"></a>
 ## Submit a Bug Report
 
 Note: DO NOT include your credentials in ANY code examples, descriptions, or media you make public.
@@ -53,7 +53,7 @@ Before you decide to create a new issue, please try the following:
 
 In order to make the process easier, we've included a [sample bug report template](https://github.com/sendgrid/sendgrid-ruby/.github/ISSUE_TEMPLATE) (borrowed from [Ghost](https://github.com/TryGhost/Ghost/)). The template uses [GitHub flavored markdown](https://help.github.com/articles/github-flavored-markdown/) for formatting.
 
-<a name="improvements_to_the_codebase"></a>
+<a name="improvements-to-the-codebase"></a>
 ## Improvements to the Codebase
 
 We welcome direct contributions to the sendgrid-ruby code base. Thank you!
@@ -113,7 +113,7 @@ Then run using:
 ruby example.rb
 ```
 
-<a name="understanding_the_codebase"></a>
+<a name="understanding-the-codebase"></a>
 ## Understanding the Code Base
 
 **/examples**
@@ -143,7 +143,7 @@ To run the tests:
 rake
 ```
 
-<a name="style_guidelines_and_naming_conventions"></a>
+<a name="style-guidelines-and-naming-conventions"></a>
 ## Style Guidelines & Naming Conventions
 
 Generally, we follow the style guidelines as suggested by the official language. However, we ask that you conform to the styles that already exist in the library. If you wish to deviate, please explain your reasoning.
@@ -154,7 +154,8 @@ Please run your code through:
 
 - [rubocop](https://github.com/bbatsov/rubocop).
 
-## Creating a Pull Request<a name="creating_a_pull_request"></a>
+<a name="creating-a-pull-request"></a>
+## Creating a Pull Request
 
 1. [Fork](https://help.github.com/fork-a-repo/) the project, clone your fork,
    and configure the remotes:

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ We appreciate your continued support, thank you!
 # Table of Contents
 
 * [Installation](#installation)
-* [Quick Start](#quick_start)
+* [Quick Start](#quick-start)
 * [Processing Inbound Email](#inbound)
 * [Usage](#usage)
 * [Use Cases](#use_cases)
@@ -68,7 +68,7 @@ gem install sendgrid-ruby
 - [Ruby-HTTP-Client](https://github.com/sendgrid/ruby-http-client)
 - [Sinatra](http://www.sinatrarb.com/) - this is only needed if you plan to process [Inbound Email](#inbound).
 
-<a name="quick_start"></a>
+<a name="quick-start"></a>
 # Quick Start
 
 ## Hello Email

--- a/USAGE.md
+++ b/USAGE.md
@@ -11,9 +11,9 @@ sg = SendGrid::API.new(api_key: ENV['SENDGRID_API_KEY'])
 
 # Table of Contents
 
-* [ACCESS SETTINGS](#access_settings)
+* [ACCESS SETTINGS](#access-settings)
 * [ALERTS](#alerts)
-* [API KEYS](#api_keys)
+* [API KEYS](#api-keys)
 * [ASM](#asm)
 * [BROWSERS](#browsers)
 * [CAMPAIGNS](#campaigns)
@@ -24,21 +24,21 @@ sg = SendGrid::API.new(api_key: ENV['SENDGRID_API_KEY'])
 * [GEO](#geo)
 * [IPS](#ips)
 * [MAIL](#mail)
-* [MAIL SETTINGS](#mail_settings)
-* [MAILBOX PROVIDERS](#mailbox_providers)
-* [PARTNER SETTINGS](#partner_settings)
+* [MAIL SETTINGS](#mail-settings)
+* [MAILBOX PROVIDERS](#mailbox-providers)
+* [PARTNER SETTINGS](#partner-settings)
 * [SCOPES](#scopes)
 * [SENDERS](#senders)
 * [STATS](#stats)
 * [SUBUSERS](#subusers)
 * [SUPPRESSION](#suppression)
 * [TEMPLATES](#templates)
-* [TRACKING SETTINGS](#tracking_settings)
+* [TRACKING SETTINGS](#tracking-settings)
 * [USER](#user)
 * [WHITELABEL](#whitelabel)
 
 
-<a name="access_settings"></a>
+<a name="access-settings"></a>
 # ACCESS SETTINGS
 
 ## Retrieve all recent access attempts
@@ -283,7 +283,7 @@ puts response.status_code
 puts response.body
 puts response.headers
 ```
-<a name="api_keys"></a>
+<a name="api-keys"></a>
 # API KEYS
 
 ## Create API keys
@@ -2249,7 +2249,7 @@ puts response.status_code
 puts response.body
 puts response.headers
 ```
-<a name="mail_settings"></a>
+<a name="mail-settings"></a>
 # MAIL SETTINGS
 
 ## Retrieve all mail settings
@@ -2619,7 +2619,7 @@ puts response.status_code
 puts response.body
 puts response.headers
 ```
-<a name="mailbox_providers"></a>
+<a name="mailbox-providers"></a>
 # MAILBOX PROVIDERS
 
 ## Retrieve email statistics by mailbox provider.
@@ -2640,7 +2640,7 @@ puts response.status_code
 puts response.body
 puts response.headers
 ```
-<a name="partner_settings"></a>
+<a name="partner-settings"></a>
 # PARTNER SETTINGS
 
 ## Returns a list of all partner settings.
@@ -3751,7 +3751,7 @@ puts response.status_code
 puts response.body
 puts response.headers
 ```
-<a name="tracking_settings"></a>
+<a name="tracking-settings"></a>
 # TRACKING SETTINGS
 
 ## Retrieve Tracking Settings
@@ -5033,4 +5033,3 @@ puts response.status_code
 puts response.body
 puts response.headers
 ```
-

--- a/USE_CASES.md
+++ b/USE_CASES.md
@@ -2,11 +2,11 @@ This documentation provides examples for specific use cases. Please [open an iss
 
 # Table of Contents
 
-* [Transactional Templates](#transactional_templates)
-* [How to Setup a Domain Whitelabel](#domain_whitelabel)
-* [How to View Email Statistics](#email_statistics)
+* [Transactional Templates](#transactional-templates)
+* [How to Setup a Domain Whitelabel](#domain-whitelabel)
+* [How to View Email Statistics](#email-statistics)
 
-<a name="transactional_templates"></a>
+<a name="transactional-templates"></a>
 # Transactional Templates
 
 For this example, we assume you have created a [transactional template](https://sendgrid.com/docs/User_Guide/Transactional_Templates/index.html). Following is the template content we used for testing.
@@ -114,14 +114,14 @@ puts response.body
 puts response.headers
 ```
 
-<a name="domain_whitelabel"></a>
+<a name="domain-whitelabel"></a>
 # How to Setup a Domain Whitelabel
 
 You can find documentation for how to setup a domain whitelabel via the UI [here](https://sendgrid.com/docs/Classroom/Basics/Whitelabel/setup_domain_whitelabel.html) and via API [here](https://github.com/sendgrid/sendgrid-ruby/blob/master/USAGE.md#whitelabel).
 
 Find more information about all of SendGrid's whitelabeling related documentation [here](https://sendgrid.com/docs/Classroom/Basics/Whitelabel/index.html).
 
-<a name="email_statistics"></a>
+<a name="email-statistics"></a>
 # How to View Email Statistics
 
 You can find documentation for how to view your email statistics via the UI [here](https://app.sendgrid.com/statistics) and via API [here](https://github.com/sendgrid/sendgrid-ruby/blob/master/USAGE.md#stats).


### PR DESCRIPTION
This is a pretty small deal, but I couldn't help but notice the section links on some of the docs were using Underscore VS Hyphen. It's a pretty minor change but should boost the searchablity of some of these sections.

For reference: https://www.seomechanic.com/seo-101-hyphens-underscores-_-urls/