### PR TITLE
Feature/217 attachment file handling

### DIFF
--- a/lib/sendgrid/helpers/mail/attachment.rb
+++ b/lib/sendgrid/helpers/mail/attachment.rb
@@ -1,4 +1,5 @@
 require 'json'
+require 'base64'
 
 module SendGrid
   class Attachment
@@ -11,11 +12,18 @@ module SendGrid
     end
 
     def content=(content)
+      @encoded_content = nil
       @content = content
     end
 
     def content
-      @content
+      return @encoded_content if @encoded_content
+
+      if @content.respond_to?(:read)
+        @encoded_content = encode @content
+      else
+        @encoded_content = @content
+      end
     end
 
     def type=(type)
@@ -58,6 +66,16 @@ module SendGrid
         'disposition' => self.disposition,
         'content_id' => self.content_id
       }.delete_if { |_, value| value.to_s.strip == '' }
+    end
+
+    private
+
+    def encode(io)
+      # Since the API expects UTF-8, we need to ensure that we're
+      # converting other formats to it so (byte-wise) Base64 encoding
+      # will come through properly on the other side.
+      str = io.read.encode('UTF-8')
+      Base64.encode64 str
     end
   end
 end

--- a/lib/sendgrid/helpers/mail/attachment.rb
+++ b/lib/sendgrid/helpers/mail/attachment.rb
@@ -71,10 +71,15 @@ module SendGrid
     private
 
     def encode(io)
+      str = io.read
       # Since the API expects UTF-8, we need to ensure that we're
       # converting other formats to it so (byte-wise) Base64 encoding
       # will come through properly on the other side.
-      str = io.read.encode('UTF-8')
+      #
+      # Not much to be done to try to handle encoding for files opened
+      # in binary mode, but at least we can faithfully convey the
+      # bytes.
+      str = str.encode('UTF-8') unless io.respond_to?(:binmode?) && io.binmode?
       Base64.encode64 str
     end
   end

--- a/test/sendgrid/helpers/mail/test_attachment.rb
+++ b/test/sendgrid/helpers/mail/test_attachment.rb
@@ -1,0 +1,34 @@
+# coding: utf-8
+require_relative "../../../../lib/sendgrid/helpers/mail/attachment"
+include SendGrid
+require "json"
+require "minitest/autorun"
+
+class TestAttachment < Minitest::Test
+  SAMPLE_INPUT = """Es blüht so grün wie Blüten blüh'n im Frühling
+Es blüht so grün wie Blüten blüh'n im Frühling
+Es blüht so grün wie Blüten blüh'n im Frühling
+Es blüht so grün wie Blüten blüh'n im Frühling
+Es blüht so grün wie Blüten blüh'n im Frühling
+""".force_encoding('UTF-8').encode
+  
+  def setup
+  end
+
+  def test_io_enocding
+    attachment = Attachment.new
+    attachment.content = StringIO.new(SAMPLE_INPUT)
+
+    expected = {
+      "content" => "RXMgYmzDvGh0IHNvIGdyw7xuIHdpZSBCbMO8dGVuIGJsw7xoJ24gaW0gRnLD\nvGhsaW5nCkVzIGJsw7xodCBzbyBncsO8biB3aWUgQmzDvHRlbiBibMO8aCdu\nIGltIEZyw7xobGluZwpFcyBibMO8aHQgc28gZ3LDvG4gd2llIEJsw7x0ZW4g\nYmzDvGgnbiBpbSBGcsO8aGxpbmcKRXMgYmzDvGh0IHNvIGdyw7xuIHdpZSBC\nbMO8dGVuIGJsw7xoJ24gaW0gRnLDvGhsaW5nCkVzIGJsw7xodCBzbyBncsO8\nbiB3aWUgQmzDvHRlbiBibMO8aCduIGltIEZyw7xobGluZwo=\n"
+    }
+
+    json = attachment.to_json
+    
+    decoded = Base64.decode64(json["content"]).force_encoding('UTF-8').encode
+
+    assert_equal(decoded, SAMPLE_INPUT)
+
+    assert_equal(json, expected)
+  end
+end

--- a/test/sendgrid/helpers/mail/test_attachment.rb
+++ b/test/sendgrid/helpers/mail/test_attachment.rb
@@ -24,7 +24,8 @@ Es blüht so grün wie Blüten blüh'n im Frühling
     }
 
     json = attachment.to_json
-    
+
+    # Double check that the decoded json matches original input.
     decoded = Base64.decode64(json["content"]).force_encoding('UTF-8').encode
 
     assert_equal(decoded, SAMPLE_INPUT)


### PR DESCRIPTION
Fix #217 by adding support to read and Base64-encode IO objects assigned as `#content`.