### PR TITLE
Allow non RFC822 formatted emails

### DIFF
--- a/lib/sendgrid/helpers/mail/email.rb
+++ b/lib/sendgrid/helpers/mail/email.rb
@@ -29,7 +29,7 @@ module SendGrid
 
     def split_email(email)
       split = /(?:(?<address>.+)\s)?<?(?<email>.+@[^>]+)>?/.match(email)
-      return split[:email], split[:address]
+      split ? [split[:email], split[:address]] : email
     end
 
     def to_json(*)

--- a/spec/sendgrid/helpers/mail/email_spec.rb
+++ b/spec/sendgrid/helpers/mail/email_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+describe SendGrid::Email do
+  describe '::new' do
+    let(:options) { { email: 'foo@bar.com' } }
+    let(:email) { SendGrid::Email.new(**options) }
+
+    it 'allows RFC822 emails' do
+      expect(email).to be_a SendGrid::Email
+    end
+
+    it 'allows non RFC822 emails' do
+      options.merge!(email: 'foo')
+
+      expect(email).to be_a SendGrid::Email
+      expect(email.email).to eq 'foo'
+    end
+  end
+end


### PR DESCRIPTION
In the case that an email doesn't explicitly conform to RFC822 (in my case I ran into it in testing), the SendGrid gem will fail with an `undefined method []` because the match is expected to work. This instead just falls back to the originally given email. Behavior originally introduced in d2063823b0ec4c88cdb8e84997ebedafa9ef655f.