### PR TITLE
Make dynamic_template_data Ruby accessor - Change method name

### DIFF
--- a/examples/helpers/mail/example.rb
+++ b/examples/helpers/mail/example.rb
@@ -133,15 +133,44 @@ def dynamic_template_data_hello_world
   mail.subject = subject
   personalization = Personalization.new
   personalization.add_to(Email.new(email: 'test1@example.com', name: 'Example User'))
-  personalization.add_dynamic_template_data({
-    "variable" => [
-      {"foo" => "bar"}, {"foo" => "baz"}
+  personalization.dynamic_template_data = {
+    variable: [
+      { foo: 'Bar' },
+      { foo: 'Baz' }
     ]
-  })
+  }
   mail.add_personalization(personalization)
+end
+
+def multiple_personalized_emails_using_one_transactional_template
+  users = [
+    { name: 'John', email: 'john@him.me', voucher_code: 'ioaudiakn' },
+    { name: 'James', email: 'john@him.me', voucher_code: 'qopieoahda' },
+    { name: 'Margaret', email: 'john@him.me', voucher_code: 'adaqwertehd' }
+  ]
+
+  mail = Mail.new
+  mail.template_id = 'YOUR_TEMPLATE_ID_HERE'
+  mail.from = Email.new(email: 'test@example.com')
+  mail.subject = 'SendGrid Dynamic Transactional Templates'
+  users.each do |user|
+    personalization = Personalization.new
+    personalization.add_to(Email.new(email: user[:email]))
+    personalization.dynamic_template_data = {
+      voucher_code: user[:voucher_code],
+      name: user[:name]
+    }
+    mail.add_personalization(personalization)
+  end
+
+  sg = SendGrid::API.new(api_key: ENV['SENDGRID_API_KEY'], host: 'https://api.sendgrid.com')
+  response = sg.client.mail._('send').post(request_body: mail.to_json)
+  puts response.status_code
+  puts response.body
+  puts response.headers
 end
 
 hello_world
 kitchen_sink
 dynamic_template_data_hello_world
-
+multiple_personalized_emails_using_one_transactional_template

--- a/lib/sendgrid/helpers/mail/personalization.rb
+++ b/lib/sendgrid/helpers/mail/personalization.rb
@@ -2,9 +2,8 @@ require 'json'
 
 module SendGrid
   class Personalization
-
-    attr_reader :tos, :ccs, :bccs, :headers, :substitutions, :custom_args,
-      :dynamic_template_data
+    attr_accessor :dynamic_template_data
+    attr_reader :tos, :ccs, :bccs, :headers, :substitutions, :custom_args
 
     def initialize
       @tos = []
@@ -51,10 +50,6 @@ module SendGrid
     def add_custom_arg(custom_arg)
       custom_arg = custom_arg.to_json
       @custom_args = @custom_args.merge(custom_arg['custom_arg'])
-    end
-
-    def add_dynamic_template_data(dynamic_template_data)
-      @dynamic_template_data.merge!(dynamic_template_data)
     end
 
     def send_at=(send_at)

--- a/test/sendgrid/helpers/mail/test_personalizations.rb
+++ b/test/sendgrid/helpers/mail/test_personalizations.rb
@@ -143,19 +143,31 @@ class TestPersonalization < Minitest::Test
     assert_equal @personalization.to_json, expected_json
   end
 
-  def test_add_dynamic_template_data
-    @personalization = Personalization.new()
-    @personalization.add_dynamic_template_data({
-        "name"=>"Example User",
-        "city"=> "Denver"
-    })
-    expected_json = {
-        "dynamic_template_data"=>{
-                "name"=>"Example User",
-                "city"=>"Denver"
-            }
+  def test_dynamic_template_data
+    personalization = Personalization.new()
+    personalization.dynamic_template_data = {
+        name: "Example User",
+        city: "Denver"
     }
-    assert_equal @personalization.to_json, expected_json
-  end
+    expected_json = {
+        dynamic_template_data: {
+            name: "Example User",
+            city: "Denver"
+        }
+    }
+    assert_equal personalization.to_json, expected_json
 
+    personalization.dynamic_template_data = personalization
+                                            .dynamic_template_data
+                                            .merge('date_of_birth', '01.06.1977')
+    expected_json = {
+        dynamic_template_data: {
+            name: "Example User",
+            city: "Denver",
+            date_of_birth: "01.06.197"
+        }
+    }
+
+    assert_equal personalization.to_json, expected_json
+  end
 end

--- a/test/sendgrid/helpers/mail/test_personalizations.rb
+++ b/test/sendgrid/helpers/mail/test_personalizations.rb
@@ -146,25 +146,25 @@ class TestPersonalization < Minitest::Test
   def test_dynamic_template_data
     personalization = Personalization.new()
     personalization.dynamic_template_data = {
-        name: "Example User",
-        city: "Denver"
+        "name" => "Example User",
+        "city" => "Denver"
     }
     expected_json = {
-        dynamic_template_data: {
-            name: "Example User",
-            city: "Denver"
+        "dynamic_template_data" => {
+            "name" => "Example User",
+            "city" => "Denver"
         }
     }
     assert_equal personalization.to_json, expected_json
 
     personalization.dynamic_template_data = personalization
                                             .dynamic_template_data
-                                            .merge('date_of_birth', '01.06.1977')
+                                            .merge('date_of_birth' => '01.06.1977')
     expected_json = {
-        dynamic_template_data: {
-            name: "Example User",
-            city: "Denver",
-            date_of_birth: "01.06.197"
+        "dynamic_template_data" => {
+            "name" => "Example User",
+            "city" => "Denver",
+            "date_of_birth" => "01.06.1977"
         }
     }
 


### PR DESCRIPTION
Fixes #308

Well it's not really a fix but an important enhancement. I think there is a lot of confusion regarding
the `add_dynamic_template_data` method. See #308 for example.

### Checklist
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guide] and my PR follows them.
- [x] I updated my branch with the master branch.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation about the functionality in the appropriate .md file
- [ ] I have added in line documentation to the code I modified

### BREAKING CHANGES

The method `add_dynamic_template_data` (unreleased) was renamed and converted into a simple Ruby accessor.
So instead of
`p.add_dynamic_template_data(foo: :bar)`, you would now do `p.dynamic_template_data = { foo: :bar }`.
