### PR TITLE
Rename .to_json to .to_hash

### DIFF
--- a/examples/helpers/mail/example.rb
+++ b/examples/helpers/mail/example.rb
@@ -116,7 +116,7 @@ def kitchen_sink
   mail.reply_to = Email.new(email: 'test@example.com')
 
   # puts JSON.pretty_generate(mail.to_json)
-  puts mail.to_json
+  puts mail.to_hash
 
   sg = SendGrid::API.new(api_key: ENV['SENDGRID_API_KEY'], host: 'https://api.sendgrid.com')
   response = sg.client.mail._('send').post(request_body: mail.to_json)
@@ -144,4 +144,3 @@ end
 hello_world
 kitchen_sink
 dynamic_template_data_hello_world
-

--- a/lib/sendgrid/helpers/mail/asm.rb
+++ b/lib/sendgrid/helpers/mail/asm.rb
@@ -23,7 +23,7 @@ module SendGrid
       @groups_to_display
     end
 
-    def to_json(*)
+    def to_hash(*)
       {
         'group_id' => self.group_id,
         'groups_to_display' => self.groups_to_display

--- a/lib/sendgrid/helpers/mail/attachment.rb
+++ b/lib/sendgrid/helpers/mail/attachment.rb
@@ -58,7 +58,7 @@ module SendGrid
       @content_id
     end
 
-    def to_json(*)
+    def to_hash(*)
       {
         'content' => self.content,
         'type' => self.type,

--- a/lib/sendgrid/helpers/mail/bcc_settings.rb
+++ b/lib/sendgrid/helpers/mail/bcc_settings.rb
@@ -23,7 +23,7 @@ module SendGrid
       @email
     end
 
-    def to_json(*)
+    def to_hash(*)
       {
         'enable' => self.enable,
         'email' => self.email

--- a/lib/sendgrid/helpers/mail/bypass_list_management.rb
+++ b/lib/sendgrid/helpers/mail/bypass_list_management.rb
@@ -14,7 +14,7 @@ module SendGrid
       @enable
     end
 
-    def to_json(*)
+    def to_hash(*)
       {
         'enable' => self.enable
       }.delete_if { |_, value| value.to_s.strip == '' }
@@ -34,7 +34,7 @@ module SendGrid
       @enable
     end
 
-    def to_json(*)
+    def to_hash(*)
       {
         'enable' => self.enable
       }.delete_if { |_, value| value.to_s.strip == '' }

--- a/lib/sendgrid/helpers/mail/category.rb
+++ b/lib/sendgrid/helpers/mail/category.rb
@@ -8,14 +8,6 @@ module SendGrid
       @name = name
     end
 
-    def name=(name)
-      @name = name
-    end
-
-    def name
-      @name
-    end
-
     def to_hash(*)
       {
         'category' => name

--- a/lib/sendgrid/helpers/mail/category.rb
+++ b/lib/sendgrid/helpers/mail/category.rb
@@ -8,7 +8,15 @@ module SendGrid
       @name = name
     end
 
-    def to_json(*)
+    def name=(name)
+      @name = name
+    end
+
+    def name
+      @name
+    end
+
+    def to_hash(*)
       {
         'category' => name
       }.delete_if { |_, value| value.to_s.strip == '' }

--- a/lib/sendgrid/helpers/mail/click_tracking.rb
+++ b/lib/sendgrid/helpers/mail/click_tracking.rb
@@ -23,7 +23,7 @@ module SendGrid
       @enable_text
     end
 
-    def to_json(*)
+    def to_hash(*)
       {
         'enable' => self.enable,
         'enable_text' => self.enable_text

--- a/lib/sendgrid/helpers/mail/content.rb
+++ b/lib/sendgrid/helpers/mail/content.rb
@@ -10,7 +10,11 @@ module SendGrid
       @value = value
     end
 
-    def to_json(*)
+    def value
+      @value
+    end
+
+    def to_hash(*)
       {
         'type' => self.type,
         'value' => self.value

--- a/lib/sendgrid/helpers/mail/custom_arg.rb
+++ b/lib/sendgrid/helpers/mail/custom_arg.rb
@@ -15,7 +15,7 @@ module SendGrid
       @custom_arg
     end
 
-    def to_json(*)
+    def to_hash(*)
       {
         'custom_arg' => self.custom_arg
       }.delete_if { |_, value| value.to_s.strip == '' }

--- a/lib/sendgrid/helpers/mail/email.rb
+++ b/lib/sendgrid/helpers/mail/email.rb
@@ -19,7 +19,7 @@ module SendGrid
       return split[:email], split[:address]
     end
 
-    def to_json(*)
+    def to_hash(*)
       {
         'email' => self.email,
         'name' => self.name

--- a/lib/sendgrid/helpers/mail/footer.rb
+++ b/lib/sendgrid/helpers/mail/footer.rb
@@ -32,7 +32,7 @@ module SendGrid
       @html
     end
 
-    def to_json(*)
+    def to_hash(*)
       {
         'enable' => self.enable,
         'text' => self.text,

--- a/lib/sendgrid/helpers/mail/ganalytics.rb
+++ b/lib/sendgrid/helpers/mail/ganalytics.rb
@@ -60,7 +60,7 @@ module SendGrid
       @utm_campaign
     end
 
-    def to_json(*)
+    def to_hash(*)
       {
         'enable' => self.enable,
         'utm_source' => self.utm_source,

--- a/lib/sendgrid/helpers/mail/header.rb
+++ b/lib/sendgrid/helpers/mail/header.rb
@@ -15,7 +15,7 @@ module SendGrid
       @header
     end
 
-    def to_json(*)
+    def to_hash(*)
       {
         'header' => self.header
       }.delete_if { |_, value| value.to_s.strip == '' }

--- a/lib/sendgrid/helpers/mail/mail.rb
+++ b/lib/sendgrid/helpers/mail/mail.rb
@@ -42,15 +42,15 @@ module SendGrid
     end
 
     def from
-      @from.nil? ? nil : @from.to_json
+      @from.nil? ? nil : @from.to_hash
     end
 
     def add_personalization(personalization)
-      @personalizations << personalization.to_json
+      @personalizations << personalization.to_hash
     end
 
     def add_content(content)
-      @contents << content.to_json
+      @contents << content.to_hash
     end
 
     def check_for_secrets(patterns)
@@ -61,7 +61,7 @@ module SendGrid
     end
 
     def add_attachment(attachment)
-      @attachments << attachment.to_json
+      @attachments << attachment.to_hash
     end
 
     def add_category(category)
@@ -69,17 +69,17 @@ module SendGrid
     end
 
     def add_section(section)
-      section = section.to_json
+      section = section.to_hash
       @sections = @sections.merge(section['section'])
     end
 
     def add_header(header)
-      header = header.to_json
+      header = header.to_hash
       @headers = @headers.merge(header['header'])
     end
 
     def add_custom_arg(custom_arg)
-      custom_arg = custom_arg.to_json
+      custom_arg = custom_arg.to_hash
       @custom_args = @custom_args.merge(custom_arg['custom_arg'])
     end
 
@@ -88,7 +88,7 @@ module SendGrid
     end
 
     def asm
-      @asm.nil? ? nil : @asm.to_json
+      @asm.nil? ? nil : @asm.to_hash
     end
 
     def mail_settings=(mail_settings)
@@ -96,7 +96,7 @@ module SendGrid
     end
 
     def mail_settings
-      @mail_settings.nil? ? nil : @mail_settings.to_json
+      @mail_settings.nil? ? nil : @mail_settings.to_hash
     end
 
     def tracking_settings=(tracking_settings)
@@ -104,7 +104,7 @@ module SendGrid
     end
 
     def tracking_settings
-      @tracking_settings.nil? ? nil : @tracking_settings.to_json
+      @tracking_settings.nil? ? nil : @tracking_settings.to_hash
     end
 
     def reply_to=(reply_to)
@@ -112,10 +112,10 @@ module SendGrid
     end
 
     def reply_to
-      @reply_to.nil? ? nil : @reply_to.to_json
+      @reply_to.nil? ? nil : @reply_to.to_hash
     end
 
-    def to_json(*)
+    def to_hash(*)
       {
         'from' => self.from,
         'subject' => self.subject,

--- a/lib/sendgrid/helpers/mail/mail_settings.rb
+++ b/lib/sendgrid/helpers/mail/mail_settings.rb
@@ -15,7 +15,7 @@ module SendGrid
     end
 
     def sandbox_mode
-      @sandbox_mode.nil? ? nil : @sandbox_mode.to_json
+      @sandbox_mode.nil? ? nil : @sandbox_mode.to_hash
     end
 
     def bypass_list_management=(bypass_list_management)
@@ -23,7 +23,7 @@ module SendGrid
     end
 
     def bypass_list_management
-      @bypass_list_management.nil? ? nil : @bypass_list_management.to_json
+      @bypass_list_management.nil? ? nil : @bypass_list_management.to_hash
     end
 
     def footer=(footer)
@@ -31,7 +31,7 @@ module SendGrid
     end
 
     def footer
-      @footer.nil? ? nil : @footer.to_json
+      @footer.nil? ? nil : @footer.to_hash
     end
 
     def bcc=(bcc)
@@ -39,7 +39,7 @@ module SendGrid
     end
 
     def bcc
-      @bcc.nil? ? nil : @bcc.to_json
+      @bcc.nil? ? nil : @bcc.to_hash
     end
 
     def spam_check=(spam_check)
@@ -47,10 +47,10 @@ module SendGrid
     end
 
     def spam_check
-      @spam_check.nil? ? nil : @spam_check.to_json
+      @spam_check.nil? ? nil : @spam_check.to_hash
     end
 
-    def to_json(*)
+    def to_hash(*)
       {
         'bcc' => self.bcc,
         'bypass_list_management' => self.bypass_list_management,

--- a/lib/sendgrid/helpers/mail/open_tracking.rb
+++ b/lib/sendgrid/helpers/mail/open_tracking.rb
@@ -23,7 +23,7 @@ module SendGrid
       @substitution_tag
     end
 
-    def to_json(*)
+    def to_hash(*)
       {
         'enable' => self.enable,
         'substitution_tag' => self.substitution_tag

--- a/lib/sendgrid/helpers/mail/personalization.rb
+++ b/lib/sendgrid/helpers/mail/personalization.rb
@@ -19,15 +19,15 @@ module SendGrid
     end
 
     def add_to(to)
-      @tos << to.to_json
+      @tos << to.to_hash
     end
 
     def add_cc(cc)
-      @ccs << cc.to_json
+      @ccs << cc.to_hash
     end
 
     def add_bcc(bcc)
-      @bccs << bcc.to_json
+      @bccs << bcc.to_hash
     end
 
     def subject=(subject)
@@ -39,17 +39,17 @@ module SendGrid
     end
 
     def add_header(header)
-      header = header.to_json
+      header = header.to_hash
       @headers = @headers.merge(header['header'])
     end
 
     def add_substitution(substitution)
-      substitution = substitution.to_json
+      substitution = substitution.to_hash
       @substitutions = @substitutions.merge(substitution['substitution'])
     end
 
     def add_custom_arg(custom_arg)
-      custom_arg = custom_arg.to_json
+      custom_arg = custom_arg.to_hash
       @custom_args = @custom_args.merge(custom_arg['custom_arg'])
     end
 
@@ -65,7 +65,7 @@ module SendGrid
       @send_at
     end
 
-    def to_json(*)
+    def to_hash(*)
       {
         'to' => self.tos,
         'cc' => self.ccs,

--- a/lib/sendgrid/helpers/mail/section.rb
+++ b/lib/sendgrid/helpers/mail/section.rb
@@ -15,7 +15,7 @@ module SendGrid
       @section
     end
 
-    def to_json(*)
+    def to_hash(*)
       {
         'section' => self.section
       }.delete_if { |_, value| value.to_s.strip == '' }

--- a/lib/sendgrid/helpers/mail/spam_check.rb
+++ b/lib/sendgrid/helpers/mail/spam_check.rb
@@ -32,7 +32,7 @@ module SendGrid
       @post_to_url
     end
 
-    def to_json(*)
+    def to_hash(*)
       {
         'enable' => self.enable,
         'threshold' => self.threshold,

--- a/lib/sendgrid/helpers/mail/subscription_tracking.rb
+++ b/lib/sendgrid/helpers/mail/subscription_tracking.rb
@@ -41,7 +41,7 @@ module SendGrid
       @substitution_tag
     end
 
-    def to_json(*)
+    def to_hash(*)
       {
         'enable' => self.enable,
         'text' => self.text,

--- a/lib/sendgrid/helpers/mail/substitution.rb
+++ b/lib/sendgrid/helpers/mail/substitution.rb
@@ -15,7 +15,7 @@ module SendGrid
       @substitution
     end
 
-    def to_json(*)
+    def to_hash(*)
       {
         'substitution' => self.substitution
       }.delete_if { |_, value| value.to_s.strip == '' }

--- a/lib/sendgrid/helpers/mail/tracking_settings.rb
+++ b/lib/sendgrid/helpers/mail/tracking_settings.rb
@@ -14,7 +14,7 @@ module SendGrid
     end
 
     def click_tracking
-      @click_tracking.nil? ? nil : @click_tracking.to_json
+      @click_tracking.nil? ? nil : @click_tracking.to_hash
     end
 
     def open_tracking=(open_tracking)
@@ -22,7 +22,7 @@ module SendGrid
     end
 
     def open_tracking
-      @open_tracking.nil? ? nil : @open_tracking.to_json
+      @open_tracking.nil? ? nil : @open_tracking.to_hash
     end
 
     def subscription_tracking=(subscription_tracking)
@@ -30,7 +30,7 @@ module SendGrid
     end
 
     def subscription_tracking
-      @subscription_tracking.nil? ? nil : @subscription_tracking.to_json
+      @subscription_tracking.nil? ? nil : @subscription_tracking.to_hash
     end
 
     def ganalytics=(ganalytics)
@@ -38,10 +38,10 @@ module SendGrid
     end
 
     def ganalytics
-      @ganalytics.nil? ? nil : @ganalytics.to_json
+      @ganalytics.nil? ? nil : @ganalytics.to_hash
     end
 
-    def to_json(*)
+    def to_hash(*)
       {
         'click_tracking' => self.click_tracking,
         'open_tracking' => self.open_tracking,

--- a/test/sendgrid/helpers/mail/test_attachment.rb
+++ b/test/sendgrid/helpers/mail/test_attachment.rb
@@ -23,7 +23,7 @@ Es blüht so grün wie Blüten blüh'n im Frühling
       "content" => "RXMgYmzDvGh0IHNvIGdyw7xuIHdpZSBCbMO8dGVuIGJsw7xoJ24gaW0gRnLD\nvGhsaW5nCkVzIGJsw7xodCBzbyBncsO8biB3aWUgQmzDvHRlbiBibMO8aCdu\nIGltIEZyw7xobGluZwpFcyBibMO8aHQgc28gZ3LDvG4gd2llIEJsw7x0ZW4g\nYmzDvGgnbiBpbSBGcsO8aGxpbmcKRXMgYmzDvGh0IHNvIGdyw7xuIHdpZSBC\nbMO8dGVuIGJsw7xoJ24gaW0gRnLDvGhsaW5nCkVzIGJsw7xodCBzbyBncsO8\nbiB3aWUgQmzDvHRlbiBibMO8aCduIGltIEZyw7xobGluZwo=\n"
     }
 
-    json = attachment.to_json
+    json = attachment.to_hash
 
     # Double check that the decoded json matches original input.
     decoded = Base64.decode64(json["content"]).force_encoding('UTF-8').encode

--- a/test/sendgrid/helpers/mail/test_category.rb
+++ b/test/sendgrid/helpers/mail/test_category.rb
@@ -21,7 +21,7 @@ class TestCategory < Minitest::Test
     expected_json = {
       'category' => 'foo'
     }
-    assert_equal @category.to_json, expected_json
+    assert_equal @category.to_hash, expected_json
   end
 
 end

--- a/test/sendgrid/helpers/mail/test_email.rb
+++ b/test/sendgrid/helpers/mail/test_email.rb
@@ -11,7 +11,7 @@ class TestEmail < Minitest::Test
         "email"=>"test1@example.com",
         "name"=>"Example User"
     }
-    assert_equal @email.to_json, expected_json
+    assert_equal @email.to_hash, expected_json
   end
 
   def test_split_email_only_email
@@ -19,7 +19,7 @@ class TestEmail < Minitest::Test
     expected_json = {
         "email"=>"test1@example.com",
     }
-    assert_equal @email.to_json, expected_json
+    assert_equal @email.to_hash, expected_json
   end
 
   def test_split_email_name_and_email
@@ -28,7 +28,7 @@ class TestEmail < Minitest::Test
         "email"=>"test1@example.com",
         "name"=>"Example User"
     }
-    assert_equal @email.to_json, expected_json
+    assert_equal @email.to_hash, expected_json
   end
 
 end

--- a/test/sendgrid/helpers/mail/test_mail.rb
+++ b/test/sendgrid/helpers/mail/test_mail.rb
@@ -15,7 +15,7 @@ class TestMail < Minitest::Test
     content = Content.new(type: 'text/plain', value: 'and easy to do anywhere, even with Ruby')
     mail = SendGrid::Mail.new(from, subject, to, content)
 
-    assert_equal(mail.to_json, JSON.parse('{"from":{"email":"test@example.com"}, "subject":"Sending with SendGrid is Fun", "personalizations":[{"to":[{"email":"test@example.com"}]}], "content":[{"type":"text/plain", "value":"and easy to do anywhere, even with Ruby"}]}'))
+    assert_equal(mail.to_hash, JSON.parse('{"from":{"email":"test@example.com"}, "subject":"Sending with SendGrid is Fun", "personalizations":[{"to":[{"email":"test@example.com"}]}], "content":[{"type":"text/plain", "value":"and easy to do anywhere, even with Ruby"}]}'))
   end
 
   def test_kitchen_sink
@@ -115,7 +115,7 @@ class TestMail < Minitest::Test
 
     mail.reply_to = Email.new(email: "test@example.com")
 
-    assert_equal(mail.to_json, JSON.parse('{"asm":{"group_id":99,"groups_to_display":[4,5,6,7,8]},"attachments":[{"content":"TG9yZW0gaXBzdW0gZG9sb3Igc2l0IGFtZXQsIGNvbnNlY3RldHVyIGFkaXBpc2NpbmcgZWxpdC4gQ3JhcyBwdW12","content_id":"Balance Sheet","disposition":"attachment","filename":"balance_001.pdf","type":"application/pdf"},{"content":"BwdW","content_id":"Banner","disposition":"inline","filename":"banner.png","type":"image/png"}],"batch_id":"sendgrid_batch_id","categories":["May","2016"],"content":[{"type":"text/plain","value":"some text here"},{"type":"text/html","value":"<html><body>some text here</body></html>"}],"custom_args":{"campaign":"welcome","weekday":"morning"},"from":{"email":"test@example.com"},"headers":{"X-Test3":"test3","X-Test4":"test4"},"ip_pool_name":"23","mail_settings":{"bcc":{"email":"test@example.com","enable":true},"bypass_list_management":{"enable":true},"footer":{"enable":true,"html":"<html><body>Footer Text</body></html>","text":"Footer Text"},"sandbox_mode":{"enable":true},"spam_check":{"enable":true,"post_to_url":"https://spamcatcher.sendgrid.com","threshold":1}},"personalizations":[{"bcc":[{"email":"test@example.com","name":"Example User"},{"email":"test@example.com","name":"Example User"}],"cc":[{"email":"test@example.com","name":"Example User"},{"email":"test@example.com","name":"Example User"}],"custom_args":{"type":"marketing","user_id":"343"},"headers":{"X-Mock":"False","X-Test":"True"},"send_at":1443636843,"subject":"Hello World from the Personalized SendGrid Python Library","substitutions":{"%city%":"Denver","%name%":"Example User"},"to":[{"email":"test@example.com","name":"Example User"},{"email":"test@example.com","name":"Example User"}]},{"bcc":[{"email":"test@example.com","name":"Example User"},{"email":"test@example.com","name":"Example User"}],"cc":[{"email":"test@example.com","name":"Example User"},{"email":"test@example.com","name":"Example User"}],"custom_args":{"type":"marketing","user_id":"343"},"headers":{"X-Mock":"False","X-Test":"True"},"send_at":1443636843,"subject":"Hello World from the Personalized SendGrid Python Library","substitutions":{"%city%":"Denver","%name%":"Example User"},"to":[{"email":"test@example.com","name":"Example User"},{"email":"test@example.com","name":"Example User"}]}],"reply_to":{"email":"test@example.com"},"sections":{"%section1%":"Substitution Text for Section 1","%section2%":"Substitution Text for Section 2"},"send_at":1443636842,"subject":"Hello World from the SendGrid Ruby Library","template_id":"13b8f94f-bcae-4ec6-b752-70d6cb59f932","tracking_settings":{"click_tracking":{"enable":false,"enable_text":false},"ganalytics":{"enable":true,"utm_campaign":"some campaign","utm_content":"some content","utm_medium":"some medium","utm_source":"some source","utm_term":"some term"},"open_tracking":{"enable":true,"substitution_tag":"Optional tag to replace with the open image in the body of the message"},"subscription_tracking":{"enable":true,"html":"html to insert into the text/html portion of the message","substitution_tag":"Optional tag to replace with the open image in the body of the message","text":"text to insert into the text/plain portion of the message"}}}'))
+    assert_equal(mail.to_hash, JSON.parse('{"asm":{"group_id":99,"groups_to_display":[4,5,6,7,8]},"attachments":[{"content":"TG9yZW0gaXBzdW0gZG9sb3Igc2l0IGFtZXQsIGNvbnNlY3RldHVyIGFkaXBpc2NpbmcgZWxpdC4gQ3JhcyBwdW12","content_id":"Balance Sheet","disposition":"attachment","filename":"balance_001.pdf","type":"application/pdf"},{"content":"BwdW","content_id":"Banner","disposition":"inline","filename":"banner.png","type":"image/png"}],"batch_id":"sendgrid_batch_id","categories":["May","2016"],"content":[{"type":"text/plain","value":"some text here"},{"type":"text/html","value":"<html><body>some text here</body></html>"}],"custom_args":{"campaign":"welcome","weekday":"morning"},"from":{"email":"test@example.com"},"headers":{"X-Test3":"test3","X-Test4":"test4"},"ip_pool_name":"23","mail_settings":{"bcc":{"email":"test@example.com","enable":true},"bypass_list_management":{"enable":true},"footer":{"enable":true,"html":"<html><body>Footer Text</body></html>","text":"Footer Text"},"sandbox_mode":{"enable":true},"spam_check":{"enable":true,"post_to_url":"https://spamcatcher.sendgrid.com","threshold":1}},"personalizations":[{"bcc":[{"email":"test@example.com","name":"Example User"},{"email":"test@example.com","name":"Example User"}],"cc":[{"email":"test@example.com","name":"Example User"},{"email":"test@example.com","name":"Example User"}],"custom_args":{"type":"marketing","user_id":"343"},"headers":{"X-Mock":"False","X-Test":"True"},"send_at":1443636843,"subject":"Hello World from the Personalized SendGrid Python Library","substitutions":{"%city%":"Denver","%name%":"Example User"},"to":[{"email":"test@example.com","name":"Example User"},{"email":"test@example.com","name":"Example User"}]},{"bcc":[{"email":"test@example.com","name":"Example User"},{"email":"test@example.com","name":"Example User"}],"cc":[{"email":"test@example.com","name":"Example User"},{"email":"test@example.com","name":"Example User"}],"custom_args":{"type":"marketing","user_id":"343"},"headers":{"X-Mock":"False","X-Test":"True"},"send_at":1443636843,"subject":"Hello World from the Personalized SendGrid Python Library","substitutions":{"%city%":"Denver","%name%":"Example User"},"to":[{"email":"test@example.com","name":"Example User"},{"email":"test@example.com","name":"Example User"}]}],"reply_to":{"email":"test@example.com"},"sections":{"%section1%":"Substitution Text for Section 1","%section2%":"Substitution Text for Section 2"},"send_at":1443636842,"subject":"Hello World from the SendGrid Ruby Library","template_id":"13b8f94f-bcae-4ec6-b752-70d6cb59f932","tracking_settings":{"click_tracking":{"enable":false,"enable_text":false},"ganalytics":{"enable":true,"utm_campaign":"some campaign","utm_content":"some content","utm_medium":"some medium","utm_source":"some source","utm_term":"some term"},"open_tracking":{"enable":true,"substitution_tag":"Optional tag to replace with the open image in the body of the message"},"subscription_tracking":{"enable":true,"html":"html to insert into the text/html portion of the message","substitution_tag":"Optional tag to replace with the open image in the body of the message","text":"text to insert into the text/plain portion of the message"}}}'))
   end
 
   def test_that_personalizations_is_empty_initially
@@ -140,14 +140,16 @@ class TestMail < Minitest::Test
 
   def test_add_personalization
     mail = SendGrid::Mail.new
-    mail.add_personalization('foo')
-    assert_equal(['foo'.to_json], mail.personalizations)
+    personalization = Personalization.new
+    personalization.add_to(Email.new(email: "test@example.com"))
+    mail.add_personalization(personalization)
+    assert_equal([{"to"=>[{"email"=>"test@example.com"}]}], mail.personalizations)
   end
 
   def test_add_content
     mail = SendGrid::Mail.new
-    mail.add_content('foo')
-    assert_equal(['foo'.to_json], mail.contents)
+    mail.add_content(Content.new(type: "text/plain"))
+    assert_equal([{"type"=>"text/plain"}], mail.contents)
   end
 
   def test_add_section
@@ -158,7 +160,7 @@ class TestMail < Minitest::Test
                 "%section1%"=>"Substitution Text for Section 1"
             }
     }
-    assert_equal mail.to_json, expected_json
+    assert_equal mail.to_hash, expected_json
     mail.add_section(Section.new(key: '%section2%', value: 'Substitution Text for Section 2'))
     expected_json = {
         "sections"=>{
@@ -166,7 +168,7 @@ class TestMail < Minitest::Test
                 "%section2%"=>"Substitution Text for Section 2"
             }
     }
-    assert_equal mail.to_json, expected_json
+    assert_equal mail.to_hash, expected_json
   end
 
   def test_add_header
@@ -177,7 +179,7 @@ class TestMail < Minitest::Test
                 "X-Test3"=>"test3"
             }
     }
-    assert_equal mail.to_json, expected_json
+    assert_equal mail.to_hash, expected_json
     mail.add_header(Header.new(key: 'X-Test4', value: 'test4'))
     expected_json = {
         "headers"=>{
@@ -185,7 +187,7 @@ class TestMail < Minitest::Test
                 "X-Test4"=>"test4"
             }
     }
-    assert_equal mail.to_json, expected_json
+    assert_equal mail.to_hash, expected_json
   end
 
   def test_add_custom_arg
@@ -196,7 +198,7 @@ class TestMail < Minitest::Test
                 "campaign 1"=>"welcome 1"
             }
     }
-    assert_equal mail.to_json, expected_json
+    assert_equal mail.to_hash, expected_json
     mail.add_custom_arg(CustomArg.new(key: 'campaign 2', value: 'welcome 2'))
     expected_json = {
         "custom_args"=>{
@@ -204,7 +206,7 @@ class TestMail < Minitest::Test
                 "campaign 2"=>"welcome 2"
             }
     }
-    assert_equal mail.to_json, expected_json
+    assert_equal mail.to_hash, expected_json
   end
 
   def test_add_non_string_custom_arg
@@ -219,13 +221,17 @@ class TestMail < Minitest::Test
                 "Hash"=>"{\"a\"=>1, \"b\"=>2}",
             }
     }
-    assert_equal mail.to_json, expected_json
+    assert_equal mail.to_hash, expected_json
   end
 
   def test_add_attachment
     mail = SendGrid::Mail.new
-    mail.add_attachment('foo')
-    assert_equal(['foo'.to_json], mail.attachments)
+
+    attachment = Attachment.new
+    attachment.type = "application/pdf"
+    mail.add_attachment(attachment)
+
+    assert_equal([{"type"=>"application/pdf"}], mail.attachments)
   end
 
   def test_add_valid_category

--- a/test/sendgrid/helpers/mail/test_personalizations.rb
+++ b/test/sendgrid/helpers/mail/test_personalizations.rb
@@ -1,5 +1,10 @@
 require_relative '../../../../lib/sendgrid/helpers/mail/personalization'
+require_relative '../../../../lib/sendgrid/helpers/mail/email'
+require_relative '../../../../lib/sendgrid/helpers/mail/header'
+require_relative '../../../../lib/sendgrid/helpers/mail/substitution'
+require_relative '../../../../lib/sendgrid/helpers/mail/custom_arg'
 require 'minitest/autorun'
+require 'pry'
 
 class TestPersonalization < Minitest::Test
 
@@ -29,7 +34,7 @@ class TestPersonalization < Minitest::Test
             }
         ]
     }
-    assert_equal @personalization.to_json, expected_json
+    assert_equal @personalization.to_hash, expected_json
   end
 
   def test_add_cc
@@ -56,7 +61,7 @@ class TestPersonalization < Minitest::Test
             }
         ]
     }
-    assert_equal @personalization.to_json, expected_json
+    assert_equal @personalization.to_hash, expected_json
   end
 
   def test_add_bcc
@@ -83,7 +88,8 @@ class TestPersonalization < Minitest::Test
             }
         ]
     }
-    assert_equal @personalization.to_json, expected_json
+
+    assert_equal @personalization.to_hash, expected_json
   end
 
   def test_add_header
@@ -94,7 +100,7 @@ class TestPersonalization < Minitest::Test
                 "X-Test"=>"True"
             }
     }
-    assert_equal @personalization.to_json, expected_json
+    assert_equal @personalization.to_hash, expected_json
     @personalization.add_header(Header.new(key: 'X-Test 1', value: 'False'))
     expected_json = {
         "headers"=>{
@@ -102,7 +108,7 @@ class TestPersonalization < Minitest::Test
                 "X-Test 1"=>"False"
             }
     }
-    assert_equal @personalization.to_json, expected_json
+    assert_equal @personalization.to_hash, expected_json
   end
 
   def test_add_substitution
@@ -113,7 +119,7 @@ class TestPersonalization < Minitest::Test
                 "%name%"=>"Example User"
             }
     }
-    assert_equal @personalization.to_json, expected_json
+    assert_equal @personalization.to_hash, expected_json
     @personalization.add_substitution(Substitution.new(key: '%name 1%', value: 'Example User 1'))
     expected_json = {
         "substitutions"=>{
@@ -121,7 +127,7 @@ class TestPersonalization < Minitest::Test
                 "%name 1%"=>"Example User 1"
             }
     }
-    assert_equal @personalization.to_json, expected_json
+    assert_equal @personalization.to_hash, expected_json
   end
 
   def test_add_custom_arg
@@ -132,7 +138,7 @@ class TestPersonalization < Minitest::Test
                 "user_id"=>"343"
             }
     }
-    assert_equal @personalization.to_json, expected_json
+    assert_equal @personalization.to_hash, expected_json
     @personalization.add_custom_arg(CustomArg.new(key: 'city', value: 'denver'))
     expected_json = {
         "custom_args"=>{
@@ -140,7 +146,7 @@ class TestPersonalization < Minitest::Test
                 "city"=>"denver"
             }
     }
-    assert_equal @personalization.to_json, expected_json
+    assert_equal @personalization.to_hash, expected_json
   end
 
   def test_add_dynamic_template_data
@@ -155,7 +161,7 @@ class TestPersonalization < Minitest::Test
                 "city"=>"Denver"
             }
     }
-    assert_equal @personalization.to_json, expected_json
+    assert_equal @personalization.to_hash, expected_json
   end
 
 end


### PR DESCRIPTION
#Fixes #334 
### Checklist
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guide] and my PR follows them.
- [x] I updated my branch with the master branch.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation about the functionality in the appropriate .md file
- [ ] I have added in line documentation to the code I modified

### Short description of what this PR does:
- JSON.parse returns a Hash and to_json also returns a hash so for clarity I renamed .to_json to .to_hash.

If you have questions, please send an email to [Sendgrid](mailto:dx@sendgrid.com), or file a Github Issue in this repository.
