### PR TITLE
[Fixes #382] Correct endpoint for single spam report requests

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2014-2018 SendGrid, Inc.
+Copyright (c) 2014-2019 SendGrid, Inc.
 
 MIT License
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -4026,7 +4026,7 @@ For more information, please see our [User Guide](https://sendgrid.com/docs/User
 
 ```ruby
 email = "test_url_param"
-response = sg.client.suppression.spam_report._(email).get()
+response = sg.client.suppression.spam_reports._(email).get()
 puts response.status_code
 puts response.body
 puts response.headers
@@ -4044,7 +4044,7 @@ For more information, please see our [User Guide](https://sendgrid.com/docs/User
 
 ```ruby
 email = "test_url_param"
-response = sg.client.suppression.spam_report._(email).delete()
+response = sg.client.suppression.spam_reports._(email).delete()
 puts response.status_code
 puts response.body
 puts response.headers

--- a/examples/suppression/suppression.rb
+++ b/examples/suppression/suppression.rb
@@ -19,9 +19,9 @@ puts response.headers
 # DELETE /suppression/blocks #
 
 data = JSON.parse('{
-  "delete_all": false, 
+  "delete_all": false,
   "emails": [
-    "example1@example.com", 
+    "example1@example.com",
     "example2@example.com"
   ]
 }')
@@ -65,9 +65,9 @@ puts response.headers
 # DELETE /suppression/bounces #
 
 data = JSON.parse('{
-  "delete_all": true, 
+  "delete_all": true,
   "emails": [
-    "example@example.com", 
+    "example@example.com",
     "example2@example.com"
   ]
 }')
@@ -112,9 +112,9 @@ puts response.headers
 # DELETE /suppression/invalid_emails #
 
 data = JSON.parse('{
-  "delete_all": false, 
+  "delete_all": false,
   "emails": [
-    "example1@example.com", 
+    "example1@example.com",
     "example2@example.com"
   ]
 }')
@@ -148,7 +148,7 @@ puts response.headers
 # GET /suppression/spam_report/{email} #
 
 email = "test_url_param"
-response = sg.client.suppression.spam_report._(email).get()
+response = sg.client.suppression.spam_reports._(email).get()
 puts response.status_code
 puts response.body
 puts response.headers
@@ -158,7 +158,7 @@ puts response.headers
 # DELETE /suppression/spam_report/{email} #
 
 email = "test_url_param"
-response = sg.client.suppression.spam_report._(email).delete()
+response = sg.client.suppression.spam_reports._(email).delete()
 puts response.status_code
 puts response.body
 puts response.headers
@@ -178,9 +178,9 @@ puts response.headers
 # DELETE /suppression/spam_reports #
 
 data = JSON.parse('{
-  "delete_all": false, 
+  "delete_all": false,
   "emails": [
-    "example1@example.com", 
+    "example1@example.com",
     "example2@example.com"
   ]
 }')

--- a/test/sendgrid/test_sendgrid-ruby.rb
+++ b/test/sendgrid/test_sendgrid-ruby.rb
@@ -1891,7 +1891,7 @@ class TestAPI < MiniTest::Test
         email = "test_url_param"
         headers = JSON.parse('{"X-Mock": 204}')
 
-        response = @sg.client.suppression.spam_report._(email).delete(request_headers: headers)
+        response = @sg.client.suppression.spam_reports._(email).delete(request_headers: headers)
 
         self.assert_equal('204', response.status_code)
     end


### PR DESCRIPTION
<!--
We appreciate the effort for this pull request but before that please make sure you read the contribution guidelines given above, then fill out the blanks below.


Please enter each Issue number you are resolving in your PR after one of the following words [Fixes, Closes, Resolves]. This will auto-link these issues and close them when this PR is merged!
e.g. 
Fixes #1
Closes #2
-->
Fixes #382

### Checklist
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guide] and my PR follows them.
- [x] I updated my branch with the master branch.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation about the functionality in the appropriate .md file
- [x] I have added in line documentation to the code I modified

### Short description of what this PR does:
Updates the single spam report retrieval and deletion endpoints to be in line with the base API. https://sendgrid.com/docs/API_Reference/Web_API_v3/spam_reports.html#Get-a-specific-spam-report-GET and also updates the License dates.