### PR TITLE
Add Checks to Avoid Email Address Duplication

### DIFF
--- a/lib/sendgrid/helpers/mail/personalization.rb
+++ b/lib/sendgrid/helpers/mail/personalization.rb
@@ -19,15 +19,24 @@ module SendGrid
     end
 
     def add_to(to)
-      @tos << to.to_json
+      json_to = to.to_json
+      unless @tos.include?(json_to) || @ccs.include?(json_to) || @bccs.include?(json_to)
+         @tos << json_to
+      end
     end
 
     def add_cc(cc)
-      @ccs << cc.to_json
+      json_cc = cc.to_json
+      unless @tos.include?(json_cc) || @ccs.include?(json_cc) || @bccs.include?(json_cc)
+        @ccs << json_cc
+      end
     end
 
     def add_bcc(bcc)
-      @bccs << bcc.to_json
+      json_bcc = bcc.to_json
+      unless @tos.include?(json_bcc) || @ccs.include?(json_bcc) || @bccs.include?(json_bcc)
+        @bccs << json_bcc
+      end
     end
 
     def subject=(subject)

--- a/test/sendgrid/helpers/mail/test_personalizations.rb
+++ b/test/sendgrid/helpers/mail/test_personalizations.rb
@@ -30,6 +30,20 @@ class TestPersonalization < Minitest::Test
         ]
     }
     assert_equal @personalization.to_json, expected_json
+    @personalization.add_to(Email.new(email: 'test2@example.com', name: 'Duplicate Example User 2'))
+    expected_json = {
+        "to"=>[
+            {
+                "email"=>"test1@example.com",
+                "name"=>"Example User"
+            },
+            {
+                "email"=>"test2@example.com",
+                "name"=>"Example User 2"
+            }
+        ]
+    }
+    assert_equal @personalization.to_json, expected_json
   end
 
   def test_add_cc
@@ -57,6 +71,20 @@ class TestPersonalization < Minitest::Test
         ]
     }
     assert_equal @personalization.to_json, expected_json
+    @personalization.add_cc(Email.new(email: 'test2@example.com', name: 'Duplicate Example User 2'))
+    expected_json = {
+        "cc"=>[
+            {
+                "email"=>"test1@example.com",
+                "name"=>"Example User"
+            },
+            {
+                "email"=>"test2@example.com",
+                "name"=>"Example User 2"
+            }
+        ]
+    }
+    assert_equal @personalization.to_json, expected_json
   end
 
   def test_add_bcc
@@ -71,6 +99,20 @@ class TestPersonalization < Minitest::Test
         ]
     }
     @personalization.add_bcc(Email.new(email: 'test2@example.com', name: 'Example User 2'))
+    expected_json = {
+        "bcc"=>[
+            {
+                "email"=>"test1@example.com",
+                "name"=>"Example User"
+            },
+            {
+                "email"=>"test2@example.com",
+                "name"=>"Example User 2"
+            }
+        ]
+    }
+    assert_equal @personalization.to_json, expected_json
+    @personalization.add_bcc(Email.new(email: 'test2@example.com', name: 'Duplicate of Example User 2'))
     expected_json = {
         "bcc"=>[
             {


### PR DESCRIPTION
<!--
We appreciate the effort for this pull request but before that please make sure you read the contribution guidelines given above, then fill out the blanks below.

**All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.**

Please enter each Issue number you are resolving in your PR after one of the following words [Fixes, Closes, Resolves]. This will auto-link these issues and close them when this PR is merged!
e.g. 
Fixes #1
Closes #2
-->
# Fixes # 

### Checklist
- [X] I acknowledge that all my contributions will be made under the project's license
- [X] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [X] I have read the [Contribution Guide] and my PR follows them.
- [X] I updated my branch with the master branch.
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation about the functionality in the appropriate .md file
- [X] I have added in line documentation to the code I modified

### Short description of what this PR does:
- Currently, emails silently fail to send if an email address is duplicated within the to, cc and/or bcc fields. 
I have added checks to ensure that a duplicate email address isn't added if the given email is already present in any of the address fields

I have also updated the relevant tests to check that if an attempt is made to add a duplicate email address to the tos, ccs or bccs, that the duplicate address does not appear in the final personalization

No documentation update was needed here as no change has been made to the implementation of the gem.
