### PR TITLE
fix: Only try to deploy once to rubygems

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,3 +27,4 @@ deploy:
   on:
     tags: true
     rvm: '2.4'
+    gem: gemfiles/Sinatra_1.gemfile


### PR DESCRIPTION
Since we have two gemfiles we are testing against, currently we will try to auto-deploy in both cases. We only need to try to deploy once.