### PR TITLE
fix: drop the starkbank dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,5 +3,3 @@ source 'http://rubygems.org'
 gemspec
 
 gem 'ruby_http_client'
-gem 'starkbank-ecdsa'
-

--- a/lib/sendgrid/helpers/eventwebhook/eventwebhook.rb
+++ b/lib/sendgrid/helpers/eventwebhook/eventwebhook.rb
@@ -1,3 +1,4 @@
+require 'base64'
 require 'digest'
 require 'openssl'
 

--- a/lib/sendgrid/helpers/eventwebhook/eventwebhook.rb
+++ b/lib/sendgrid/helpers/eventwebhook/eventwebhook.rb
@@ -1,4 +1,6 @@
-require 'starkbank-ecdsa'
+require 'digest'
+require 'openssl'
+
 module SendGrid
   # This class allows you to use the Event Webhook feature. Read the docs for
   # more details: https://sendgrid.com/docs/for-developers/tracking-events/event
@@ -8,7 +10,7 @@ module SendGrid
     #
     def convert_public_key_to_ecdsa(public_key)
       verify_engine
-      EllipticCurve::PublicKey.fromString(public_key)
+      OpenSSL::PKey::EC.new(Base64.decode64(public_key))
     end
 
     # * *Args* :
@@ -19,9 +21,10 @@ module SendGrid
     def verify_signature(public_key, payload, signature, timestamp)
       verify_engine
       timestamped_playload = timestamp + payload
-      decoded_signature = EllipticCurve::Signature.fromBase64(signature)
+      payload_digest = Digest::SHA256.digest(timestamped_playload)
+      decoded_signature = Base64.decode64(signature)
 
-      EllipticCurve::Ecdsa.verify(timestamped_playload, decoded_signature, public_key)
+      public_key.dsa_verify_asn1(payload_digest, decoded_signature)
     end
 
     def verify_engine

--- a/sendgrid-ruby.gemspec
+++ b/sendgrid-ruby.gemspec
@@ -20,7 +20,6 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(/^(test|spec|features)/)
   spec.require_paths = ['lib']
   spec.add_dependency 'ruby_http_client', '~> 3.4'
-  spec.add_dependency 'starkbank-ecdsa', '~> 0.0.2'
   spec.add_development_dependency 'sinatra', '>= 1.4.7', '< 3'
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rspec'


### PR DESCRIPTION
Fixes https://github.com/sendgrid/sendgrid-ruby/issues/426

Since we have a pretty light dependency on the starkbank implementation and it's causing issues with File operations, this change drops the dependency with minimal added code.