### PR TITLE
Fix: trying to add a nil substitution to a personalization throws an error

### DIFF
--- a/lib/sendgrid/helpers/mail/personalization.rb
+++ b/lib/sendgrid/helpers/mail/personalization.rb
@@ -43,6 +43,7 @@ module SendGrid
 
     def add_substitution(substitution)
       substitution = substitution.to_json
+      return if substitution['substitution'].nil?
       @substitutions = @substitutions.merge(substitution['substitution'])
     end
 

--- a/test/sendgrid/helpers/mail/test_personalizations.rb
+++ b/test/sendgrid/helpers/mail/test_personalizations.rb
@@ -124,6 +124,24 @@ class TestPersonalization < Minitest::Test
     assert_equal @personalization.to_json, expected_json
   end
 
+  def test_add_nil_substitution
+    @personalization = Personalization.new()
+    @personalization.add_substitution(Substitution.new(key: '%name%', value: 'Example User'))
+    expected_json = {
+        "substitutions"=>{
+                "%name%"=>"Example User"
+            }
+    }
+    assert_equal @personalization.to_json, expected_json
+    @personalization.add_substitution(Substitution.new(key: '%name 1%', value: nil))
+    expected_json = {
+        "substitutions"=>{
+                "%name%"=>"Example User",
+            }
+    }
+    assert_equal @personalization.to_json, expected_json
+  end
+
   def test_add_custom_arg
     @personalization = Personalization.new()
     @personalization.add_custom_arg(CustomArg.new(key: 'user_id', value: '343'))


### PR DESCRIPTION
# Fixes #

If you create a substitution with a nil value, the codebase throws an error if you try to add that substitution to a personalization.

```ruby
personalization = SendGrid::Personalization.new
personalization.add_substitution(Sendgrid::Substitution.new(key: '%FIRST_NAME%", value: nil))

=> TypeError (no implicit conversion of nil into Hash)
```

My change will ignore any nil substitutions.

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the master branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation about the functionality in the appropriate .md file
- [ ] I have added inline documentation to the code I modified

If you have questions, please file a [support ticket](https://twilio.com/help/contact), or create a GitHub Issue in this repository.
