### PR TITLE
fix!: Raise error when adding duplicate email address in Personalizations

### DIFF
--- a/lib/sendgrid/helpers/mail/personalization.rb
+++ b/lib/sendgrid/helpers/mail/personalization.rb
@@ -20,14 +20,20 @@ module SendGrid
     end
 
     def add_to(to)
+      raise DuplicatePersonalizationError if duplicate?(to)
+
       @tos << to.to_json
     end
 
     def add_cc(cc)
+      raise DuplicatePersonalizationError if duplicate?(cc)
+
       @ccs << cc.to_json
     end
 
     def add_bcc(bcc)
+      raise DuplicatePersonalizationError if duplicate?(bcc)
+
       @bccs << bcc.to_json
     end
 
@@ -63,5 +69,19 @@ module SendGrid
         'send_at' => send_at
       }.delete_if { |_, value| value.to_s.strip == '' || value == [] || value == {} }
     end
+
+    private
+
+    def duplicate?(addition)
+      additional_email = addition.email.downcase
+
+      [@tos, @ccs, @bccs].flatten.each do |elm|
+        return true if elm&.dig('email') == additional_email
+      end
+
+      false
+    end
   end
+
+  class DuplicatePersonalizationError < StandardError; end
 end

--- a/test/sendgrid/helpers/mail/test_mail.rb
+++ b/test/sendgrid/helpers/mail/test_mail.rb
@@ -22,12 +22,12 @@ class TestMail < Minitest::Test
     mail.from = Email.new(email: 'test@example.com')
     mail.subject = 'Hello World from the Twilio SendGrid Ruby Library'
     personalization = Personalization.new
-    personalization.add_to(Email.new(email: 'test@example.com', name: 'Example User'))
-    personalization.add_to(Email.new(email: 'test@example.com', name: 'Example User'))
-    personalization.add_cc(Email.new(email: 'test@example.com', name: 'Example User'))
-    personalization.add_cc(Email.new(email: 'test@example.com', name: 'Example User'))
-    personalization.add_bcc(Email.new(email: 'test@example.com', name: 'Example User'))
-    personalization.add_bcc(Email.new(email: 'test@example.com', name: 'Example User'))
+    personalization.add_to(Email.new(email: 'test1@example.com', name: 'Example User 1'))
+    personalization.add_to(Email.new(email: 'test2@example.com', name: 'Example User 2'))
+    personalization.add_cc(Email.new(email: 'test3@example.com', name: 'Example User 3'))
+    personalization.add_cc(Email.new(email: 'test4@example.com', name: 'Example User 4'))
+    personalization.add_bcc(Email.new(email: 'test5@example.com', name: 'Example User 5'))
+    personalization.add_bcc(Email.new(email: 'test6@example.com', name: 'Example User 6'))
     personalization.subject = 'Hello World from the Personalized Twilio SendGrid Ruby Library'
     personalization.add_header(Header.new(key: 'X-Test', value: 'True'))
     personalization.add_header(Header.new(key: 'X-Mock', value: 'False'))
@@ -39,12 +39,12 @@ class TestMail < Minitest::Test
     mail.add_personalization(personalization)
 
     personalization2 = Personalization.new
-    personalization2.add_to(Email.new(email: 'test@example.com', name: 'Example User'))
-    personalization2.add_to(Email.new(email: 'test@example.com', name: 'Example User'))
-    personalization2.add_cc(Email.new(email: 'test@example.com', name: 'Example User'))
-    personalization2.add_cc(Email.new(email: 'test@example.com', name: 'Example User'))
-    personalization2.add_bcc(Email.new(email: 'test@example.com', name: 'Example User'))
-    personalization2.add_bcc(Email.new(email: 'test@example.com', name: 'Example User'))
+    personalization2.add_to(Email.new(email: 'test1@example.com', name: 'Example User 1'))
+    personalization2.add_to(Email.new(email: 'test2@example.com', name: 'Example User 2'))
+    personalization2.add_cc(Email.new(email: 'test3@example.com', name: 'Example User 3'))
+    personalization2.add_cc(Email.new(email: 'test4@example.com', name: 'Example User 4'))
+    personalization2.add_bcc(Email.new(email: 'test5@example.com', name: 'Example User 5'))
+    personalization2.add_bcc(Email.new(email: 'test6@example.com', name: 'Example User 6'))
     personalization2.subject = 'Hello World from the Personalized Twilio SendGrid Ruby Library'
     personalization2.add_header(Header.new(key: 'X-Test', value: 'True'))
     personalization2.add_header(Header.new(key: 'X-Mock', value: 'False'))
@@ -114,7 +114,9 @@ class TestMail < Minitest::Test
 
     mail.reply_to = Email.new(email: 'test@example.com')
 
-    assert_equal(mail.to_json, JSON.parse('{"asm":{"group_id":99,"groups_to_display":[4,5,6,7,8]},"attachments":[{"content":"TG9yZW0gaXBzdW0gZG9sb3Igc2l0IGFtZXQsIGNvbnNlY3RldHVyIGFkaXBpc2NpbmcgZWxpdC4gQ3JhcyBwdW12","content_id":"Balance Sheet","disposition":"attachment","filename":"balance_001.pdf","type":"application/pdf"},{"content":"BwdW","content_id":"Banner","disposition":"inline","filename":"banner.png","type":"image/png"}],"batch_id":"sendgrid_batch_id","categories":["May","2016"],"content":[{"type":"text/plain","value":"some text here"},{"type":"text/html","value":"<html><body>some text here</body></html>"}],"custom_args":{"campaign":"welcome","weekday":"morning"},"from":{"email":"test@example.com"},"headers":{"X-Test3":"test3","X-Test4":"test4"},"ip_pool_name":"23","mail_settings":{"bcc":{"email":"test@example.com","enable":true},"bypass_list_management":{"enable":true},"footer":{"enable":true,"html":"<html><body>Footer Text</body></html>","text":"Footer Text"},"sandbox_mode":{"enable":true},"spam_check":{"enable":true,"post_to_url":"https://spamcatcher.sendgrid.com","threshold":1}},"personalizations":[{"bcc":[{"email":"test@example.com","name":"Example User"},{"email":"test@example.com","name":"Example User"}],"cc":[{"email":"test@example.com","name":"Example User"},{"email":"test@example.com","name":"Example User"}],"custom_args":{"type":"marketing","user_id":"343"},"headers":{"X-Mock":"False","X-Test":"True"},"send_at":1443636843,"subject":"Hello World from the Personalized Twilio SendGrid Ruby Library","substitutions":{"%city%":"Denver","%name%":"Example User"},"to":[{"email":"test@example.com","name":"Example User"},{"email":"test@example.com","name":"Example User"}]},{"bcc":[{"email":"test@example.com","name":"Example User"},{"email":"test@example.com","name":"Example User"}],"cc":[{"email":"test@example.com","name":"Example User"},{"email":"test@example.com","name":"Example User"}],"custom_args":{"type":"marketing","user_id":"343"},"headers":{"X-Mock":"False","X-Test":"True"},"send_at":1443636843,"subject":"Hello World from the Personalized Twilio SendGrid Ruby Library","substitutions":{"%city%":"Denver","%name%":"Example User"},"to":[{"email":"test@example.com","name":"Example User"},{"email":"test@example.com","name":"Example User"}]}],"reply_to":{"email":"test@example.com"},"sections":{"%section1%":"Substitution Text for Section 1","%section2%":"Substitution Text for Section 2"},"send_at":1443636842,"subject":"Hello World from the Twilio SendGrid Ruby Library","template_id":"13b8f94f-bcae-4ec6-b752-70d6cb59f932","tracking_settings":{"click_tracking":{"enable":false,"enable_text":false},"ganalytics":{"enable":true,"utm_campaign":"some campaign","utm_content":"some content","utm_medium":"some medium","utm_source":"some source","utm_term":"some term"},"open_tracking":{"enable":true,"substitution_tag":"Optional tag to replace with the open image in the body of the message"},"subscription_tracking":{"enable":true,"html":"html to insert into the text/html portion of the message","substitution_tag":"Optional tag to replace with the open image in the body of the message","text":"text to insert into the text/plain portion of the message"}}}'))
+    # rubocop:disable Layout/LineLength
+    assert_equal(mail.to_json, JSON.parse('{"asm":{"group_id":99,"groups_to_display":[4,5,6,7,8]},"attachments":[{"content":"TG9yZW0gaXBzdW0gZG9sb3Igc2l0IGFtZXQsIGNvbnNlY3RldHVyIGFkaXBpc2NpbmcgZWxpdC4gQ3JhcyBwdW12","content_id":"Balance Sheet","disposition":"attachment","filename":"balance_001.pdf","type":"application/pdf"},{"content":"BwdW","content_id":"Banner","disposition":"inline","filename":"banner.png","type":"image/png"}],"batch_id":"sendgrid_batch_id","categories":["May","2016"],"content":[{"type":"text/plain","value":"some text here"},{"type":"text/html","value":"<html><body>some text here</body></html>"}],"custom_args":{"campaign":"welcome","weekday":"morning"},"from":{"email":"test@example.com"},"headers":{"X-Test3":"test3","X-Test4":"test4"},"ip_pool_name":"23","mail_settings":{"bcc":{"email":"test@example.com","enable":true},"bypass_list_management":{"enable":true},"footer":{"enable":true,"html":"<html><body>Footer Text</body></html>","text":"Footer Text"},"sandbox_mode":{"enable":true},"spam_check":{"enable":true,"post_to_url":"https://spamcatcher.sendgrid.com","threshold":1}},"personalizations":[{"bcc":[{"email":"test5@example.com","name":"Example User 5"},{"email":"test6@example.com","name":"Example User 6"}],"cc":[{"email":"test3@example.com","name":"Example User 3"},{"email":"test4@example.com","name":"Example User 4"}],"custom_args":{"type":"marketing","user_id":"343"},"headers":{"X-Mock":"False","X-Test":"True"},"send_at":1443636843,"subject":"Hello World from the Personalized Twilio SendGrid Ruby Library","substitutions":{"%city%":"Denver","%name%":"Example User"},"to":[{"email":"test1@example.com","name":"Example User 1"},{"email":"test2@example.com","name":"Example User 2"}]},{"bcc":[{"email":"test5@example.com","name":"Example User 5"},{"email":"test6@example.com","name":"Example User 6"}],"cc":[{"email":"test3@example.com","name":"Example User 3"},{"email":"test4@example.com","name":"Example User 4"}],"custom_args":{"type":"marketing","user_id":"343"},"headers":{"X-Mock":"False","X-Test":"True"},"send_at":1443636843,"subject":"Hello World from the Personalized Twilio SendGrid Ruby Library","substitutions":{"%city%":"Denver","%name%":"Example User"},"to":[{"email":"test1@example.com","name":"Example User 1"},{"email":"test2@example.com","name":"Example User 2"}]}],"reply_to":{"email":"test@example.com"},"sections":{"%section1%":"Substitution Text for Section 1","%section2%":"Substitution Text for Section 2"},"send_at":1443636842,"subject":"Hello World from the Twilio SendGrid Ruby Library","template_id":"13b8f94f-bcae-4ec6-b752-70d6cb59f932","tracking_settings":{"click_tracking":{"enable":false,"enable_text":false},"ganalytics":{"enable":true,"utm_campaign":"some campaign","utm_content":"some content","utm_medium":"some medium","utm_source":"some source","utm_term":"some term"},"open_tracking":{"enable":true,"substitution_tag":"Optional tag to replace with the open image in the body of the message"},"subscription_tracking":{"enable":true,"html":"html to insert into the text/html portion of the message","substitution_tag":"Optional tag to replace with the open image in the body of the message","text":"text to insert into the text/plain portion of the message"}}}'))
+    # rubocop:enable all
   end
 
   def test_that_personalizations_is_empty_initially

--- a/test/sendgrid/helpers/mail/test_personalizations.rb
+++ b/test/sendgrid/helpers/mail/test_personalizations.rb
@@ -23,6 +23,19 @@ class TestPersonalization < Minitest::Test
     assert_equal @personalization.to_json, expected_json
   end
 
+  def test_duplicate_add_to
+    @personalization = Personalization.new
+    @personalization.add_to(Email.new(email: 'test1@example.com', name: 'Example User'))
+
+    assert_raises(DuplicatePersonalizationError) do
+      @personalization.add_to(Email.new(email: 'test1@example.com', name: 'Duplicate User'))
+    end
+
+    assert_raises(DuplicatePersonalizationError) do
+      @personalization.add_to(Email.new(email: 'TEST1@EXAMPLE.COM', name: 'Duplicate User'))
+    end
+  end
+
   def test_add_cc
     @personalization = Personalization.new
     @personalization.add_cc(Email.new(email: 'test1@example.com', name: 'Example User'))
@@ -42,6 +55,19 @@ class TestPersonalization < Minitest::Test
     assert_equal @personalization.to_json, expected_json
   end
 
+  def test_duplicate_add_cc
+    @personalization = Personalization.new
+    @personalization.add_cc(Email.new(email: 'test1@example.com', name: 'Example User'))
+
+    assert_raises(DuplicatePersonalizationError) do
+      @personalization.add_cc(Email.new(email: 'test1@example.com', name: 'Duplicate User'))
+    end
+
+    assert_raises(DuplicatePersonalizationError) do
+      @personalization.add_cc(Email.new(email: 'TEST1@EXAMPLE.COM', name: 'Duplicate User'))
+    end
+  end
+
   def test_add_bcc
     @personalization = Personalization.new
     @personalization.add_bcc(Email.new(email: 'test1@example.com', name: 'Example User'))
@@ -59,6 +85,19 @@ class TestPersonalization < Minitest::Test
       ]
     }
     assert_equal @personalization.to_json, expected_json
+  end
+
+  def test_duplicate_add_bcc
+    @personalization = Personalization.new
+    @personalization.add_bcc(Email.new(email: 'test1@example.com', name: 'Example User'))
+
+    assert_raises(DuplicatePersonalizationError) do
+      @personalization.add_bcc(Email.new(email: 'test1@example.com', name: 'Duplicate User'))
+    end
+
+    assert_raises(DuplicatePersonalizationError) do
+      @personalization.add_bcc(Email.new(email: 'TEST1@EXAMPLE.COM', name: 'Duplicate User'))
+    end
   end
 
   def test_add_header


### PR DESCRIPTION
fix: Checking duplicate email address specified into personalizations as case insensitive


# Fixes #436

Checking duplicate email address specified into personalizations as case insensitive

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation about the functionality in the appropriate .md file
- [x] I have added inline documentation to the code I modified