### PR TITLE
fix: Accurate duplicate checking when adding email to Personalizations

### DIFF
--- a/lib/sendgrid/helpers/mail/personalization.rb
+++ b/lib/sendgrid/helpers/mail/personalization.rb
@@ -76,7 +76,7 @@ module SendGrid
       additional_email = addition.email.downcase
 
       [@tos, @ccs, @bccs].flatten.each do |elm|
-        return true if elm&.dig('email') == additional_email
+        return true if elm&.dig('email')&.downcase == additional_email
       end
 
       false

--- a/test/sendgrid/helpers/mail/test_personalizations.rb
+++ b/test/sendgrid/helpers/mail/test_personalizations.rb
@@ -26,6 +26,7 @@ class TestPersonalization < Minitest::Test
   def test_duplicate_add_to
     @personalization = Personalization.new
     @personalization.add_to(Email.new(email: 'test1@example.com', name: 'Example User'))
+    @personalization.add_to(Email.new(email: 'TEST2@EXAMPLE.COM', name: 'Example User 2'))
 
     assert_raises(DuplicatePersonalizationError) do
       @personalization.add_to(Email.new(email: 'test1@example.com', name: 'Duplicate User'))
@@ -33,6 +34,14 @@ class TestPersonalization < Minitest::Test
 
     assert_raises(DuplicatePersonalizationError) do
       @personalization.add_to(Email.new(email: 'TEST1@EXAMPLE.COM', name: 'Duplicate User'))
+    end
+
+    assert_raises(DuplicatePersonalizationError) do
+      @personalization.add_to(Email.new(email: 'test2@example.com', name: 'Duplicate User 2'))
+    end
+
+    assert_raises(DuplicatePersonalizationError) do
+      @personalization.add_to(Email.new(email: 'TEST2@EXAMPLE.COM', name: 'Duplicate User 2'))
     end
   end
 
@@ -58,6 +67,7 @@ class TestPersonalization < Minitest::Test
   def test_duplicate_add_cc
     @personalization = Personalization.new
     @personalization.add_cc(Email.new(email: 'test1@example.com', name: 'Example User'))
+    @personalization.add_cc(Email.new(email: 'TEST2@EXAMPLE.COM', name: 'Example User 2'))
 
     assert_raises(DuplicatePersonalizationError) do
       @personalization.add_cc(Email.new(email: 'test1@example.com', name: 'Duplicate User'))
@@ -65,6 +75,14 @@ class TestPersonalization < Minitest::Test
 
     assert_raises(DuplicatePersonalizationError) do
       @personalization.add_cc(Email.new(email: 'TEST1@EXAMPLE.COM', name: 'Duplicate User'))
+    end
+
+    assert_raises(DuplicatePersonalizationError) do
+      @personalization.add_cc(Email.new(email: 'test2@example.com', name: 'Duplicate User 2'))
+    end
+
+    assert_raises(DuplicatePersonalizationError) do
+      @personalization.add_cc(Email.new(email: 'TEST2@EXAMPLE.COM', name: 'Duplicate User 2'))
     end
   end
 
@@ -90,6 +108,7 @@ class TestPersonalization < Minitest::Test
   def test_duplicate_add_bcc
     @personalization = Personalization.new
     @personalization.add_bcc(Email.new(email: 'test1@example.com', name: 'Example User'))
+    @personalization.add_bcc(Email.new(email: 'TEST2@EXAMPLE.COM', name: 'Example User 2'))
 
     assert_raises(DuplicatePersonalizationError) do
       @personalization.add_bcc(Email.new(email: 'test1@example.com', name: 'Duplicate User'))
@@ -97,6 +116,14 @@ class TestPersonalization < Minitest::Test
 
     assert_raises(DuplicatePersonalizationError) do
       @personalization.add_bcc(Email.new(email: 'TEST1@EXAMPLE.COM', name: 'Duplicate User'))
+    end
+
+    assert_raises(DuplicatePersonalizationError) do
+      @personalization.add_bcc(Email.new(email: 'test2@example.com', name: 'Duplicate User 2'))
+    end
+
+    assert_raises(DuplicatePersonalizationError) do
+      @personalization.add_bcc(Email.new(email: 'TEST2@EXAMPLE.COM', name: 'Duplicate User 2'))
     end
   end
 


### PR DESCRIPTION
# Fixes #445

Compare in downcase.

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](https://github.com/sendgrid/sendgrid-ruby/blob/main/CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation about the functionality in the appropriate .md file
- [x] I have added inline documentation to the code I modified
