### PR TITLE
feat: Add http_options as a param in the SendGrid::API's constructor

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -34,6 +34,8 @@ Metrics/BlockLength:
 # Configuration parameters: CountComments, CountAsOne.
 Metrics/ClassLength:
   Max: 2006
+  Exclude:
+    - 'test/sendgrid/test_sendgrid-ruby.rb'
 
 # Offense count: 41
 # Configuration parameters: CountComments, CountAsOne, ExcludedMethods.

--- a/lib/sendgrid/base_interface.rb
+++ b/lib/sendgrid/base_interface.rb
@@ -4,7 +4,7 @@ require_relative 'version'
 # Initialize the HTTP client
 class BaseInterface
   attr_accessor :client
-  attr_reader :request_headers, :host, :version, :impersonate_subuser
+  attr_reader :request_headers, :host, :version, :impersonate_subuser, :http_options
 
   # * *Args* :
   #   - +auth+ -> authorization header value
@@ -14,8 +14,9 @@ class BaseInterface
   #                  currently only "v3" is supported
   #   - +impersonate_subuser+ -> the subuser to impersonate, will be passed
   #                              in the "On-Behalf-Of" header
+  #   - +http_options+ -> http options that you want to be globally applied to each request
   #
-  def initialize(auth:, host:, request_headers: nil, version: nil, impersonate_subuser: nil)
+  def initialize(auth:, host:, request_headers: nil, version: nil, impersonate_subuser: nil, http_options: {})
     @auth = auth
     @host = host
     @version = version || 'v3'
@@ -31,7 +32,9 @@ class BaseInterface
     @request_headers['On-Behalf-Of'] = @impersonate_subuser if @impersonate_subuser
 
     @request_headers = @request_headers.merge(request_headers) if request_headers
+    @http_options = http_options
     @client = SendGrid::Client.new(host: "#{@host}/#{@version}",
-                                   request_headers: @request_headers)
+                                   request_headers: @request_headers,
+                                   http_options: @http_options)
   end
 end

--- a/lib/sendgrid/sendgrid.rb
+++ b/lib/sendgrid/sendgrid.rb
@@ -9,12 +9,13 @@ module SendGrid
     #                  currently only "v3" is supported
     #   - +impersonate_subuser+ -> the subuser to impersonate, will be passed
     #                              in the "On-Behalf-Of" header
+    #   - +http_options+ -> http options that you want to be globally applied to each request
     #
-    def initialize(api_key:, host: nil, request_headers: nil, version: nil, impersonate_subuser: nil)
+    def initialize(api_key:, host: nil, request_headers: nil, version: nil, impersonate_subuser: nil, http_options: {})
       auth = "Bearer #{api_key}"
       host ||= 'https://api.sendgrid.com'
 
-      super(auth: auth, host: host, request_headers: request_headers, version: version, impersonate_subuser: impersonate_subuser)
+      super(auth: auth, host: host, request_headers: request_headers, version: version, impersonate_subuser: impersonate_subuser, http_options: http_options)
     end
   end
 end

--- a/test/sendgrid/test_sendgrid-ruby.rb
+++ b/test/sendgrid/test_sendgrid-ruby.rb
@@ -44,17 +44,20 @@ class TestAPI < MiniTest::Test
   end
 
   def test_init_when_http_options_is_given
+    params = JSON.parse('{"subuser": "test_string", "ip": "test_string", "limit": 1, "exclude_whitelabels": "true", "offset": 1}')
     headers = JSON.parse('{"X-Mock": 200}')
     http_options = {
       open_timeout: 40,
       read_timeout: 40
     }
 
-    sg = SendGrid::API.new(api_key: 'SENDGRID_API_KEY', host: 'https://api.test.com', request_headers: headers, version: 'v3', http_options: http_options)
-    sg.client.get
+    sg = SendGrid::API.new(api_key: 'SENDGRID_API_KEY', version: 'v3', http_options: http_options)
+    client = sg.client.ips
+    response = client.get(query_params: params, request_headers: headers)
 
-    assert_equal(40, sg.client.http.open_timeout)
-    assert_equal(40, sg.client.http.read_timeout)
+    assert_equal(40, client.http.open_timeout)
+    assert_equal(40, client.http.read_timeout)
+    assert_equal('200', response.status_code)
   end
 
   def test_access_settings_activity_get

--- a/test/sendgrid/test_sendgrid-ruby.rb
+++ b/test/sendgrid/test_sendgrid-ruby.rb
@@ -35,11 +35,26 @@ class TestAPI < MiniTest::Test
     assert_equal(subuser, sg.impersonate_subuser)
     assert_equal('6.3.8', SendGrid::VERSION)
     assert_instance_of(SendGrid::Client, sg.client)
+    assert_equal({}, sg.http_options)
   end
 
   def test_init_when_impersonate_subuser_is_not_given
     sg = SendGrid::API.new(api_key: 'SENDGRID_API_KEY', host: 'https://api.test.com', version: 'v3')
     refute_includes(sg.request_headers, 'On-Behalf-Of')
+  end
+
+  def test_init_when_http_options_is_given
+    headers = JSON.parse('{"X-Mock": 200}')
+    http_options = {
+      open_timeout: 40,
+      read_timeout: 40
+    }
+
+    sg = SendGrid::API.new(api_key: 'SENDGRID_API_KEY', host: 'https://api.test.com', request_headers: headers, version: 'v3', http_options: http_options)
+    sg.client.get
+
+    assert_equal(40, sg.client.http.open_timeout)
+    assert_equal(40, sg.client.http.read_timeout)
   end
 
   def test_access_settings_activity_get


### PR DESCRIPTION
Closes #449

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](https://github.com/sendgrid/sendgrid-ruby/blob/main/CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added inline documentation to the code I modified