### PR TITLE
fix: email is required

### DIFF
--- a/lib/sendgrid/helpers/mail/email.rb
+++ b/lib/sendgrid/helpers/mail/email.rb
@@ -4,7 +4,9 @@ module SendGrid
   class Email
     attr_accessor :email, :name
 
-    def initialize(email: nil, name: nil)
+    # @param [String] email required e-mail address
+    # @param [String] name optionally personification
+    def initialize(email:, name: nil)
       if name
         @email = email
         @name = name
@@ -15,6 +17,8 @@ module SendGrid
 
     def split_email(email)
       split = /(?:(?<address>.+)\s)?<?(?<email>.+@[^>]+)>?/.match(email)
+      raise ArgumentError, "email (#{email}) is invalid" unless split
+
       [split[:email], split[:address]]
     end
 

--- a/test/sendgrid/helpers/mail/test_email.rb
+++ b/test/sendgrid/helpers/mail/test_email.rb
@@ -29,4 +29,14 @@ class TestEmail < Minitest::Test
     }
     assert_equal @email.to_json, expected_json
   end
+
+  def test_mandatory_email_missing
+    assert_raises(ArgumentError) { Email.new(email: nil) }
+    assert_raises(ArgumentError) { Email.new(email: "") }
+  end
+
+  def test_invalid_email
+    assert_raises(ArgumentError) { Email.new(email: "some-invalid-string") }
+  end
+
 end

--- a/test/sendgrid/helpers/mail/test_email.rb
+++ b/test/sendgrid/helpers/mail/test_email.rb
@@ -38,5 +38,4 @@ class TestEmail < Minitest::Test
   def test_invalid_email
     assert_raises(ArgumentError) { Email.new(email: "some-invalid-string") }
   end
-
 end


### PR DESCRIPTION
<!--
We appreciate the effort for this pull request but before that please make sure you read the contribution guidelines, then fill out the blanks below.

Please format the PR title appropriately based on the type of change:
  <type>[!]: <description>
Where <type> is one of: docs, chore, feat, fix, test.
Add a '!' after the type for breaking changes (e.g. feat!: new breaking feature).

**All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.**

Please enter each Issue number you are resolving in your PR after one of the following words [Fixes, Closes, Resolves]. This will auto-link these issues and close them when this PR is merged!
e.g.
Fixes #1
Closes #2
-->

# chore: `SendGrid::Email` mandatory email argument

class in constructor have definition `email: nil` but actually it can't work without "email". I think it can be confused. If I pass blank or invalid string there, it fail in `split_email` method => I suggest to raise ArgumentError with explanation instead.

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](https://github.com/sendgrid/sendgrid-ruby/blob/main/CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation about the functionality in the appropriate .md file
- [x] I have added inline documentation to the code I modified

