### PR TITLE
chore: add support for ruby 3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: ruby
 env:
+- version=ruby:3.0
 - version=ruby:2.7
 - version=ruby:2.6
 - version=ruby:2.5

--- a/spec/sendgrid/helpers/settings/mail_settings_dto_spec.rb
+++ b/spec/sendgrid/helpers/settings/mail_settings_dto_spec.rb
@@ -19,14 +19,14 @@ describe SendGrid::MailSettingsDto do
   describe '.fetch' do
     it 'calls get on sendgrid_client' do
       args = { sendgrid_client: sendgrid_client, name: setting_name, query_params: {} }
-      expect(mail_settings.fetch(args)).to be_a SendGrid::Response
+      expect(mail_settings.fetch(**args)).to be_a SendGrid::Response
     end
   end
 
   describe '.update' do
     it 'calls patch on sendgrid_client' do
       args = { sendgrid_client: sendgrid_client, name: setting_name, request_body: setting_params }
-      expect(mail_settings.update(args)).to be_a SendGrid::Response
+      expect(mail_settings.update(**args)).to be_a SendGrid::Response
     end
   end
 end

--- a/spec/sendgrid/helpers/settings/partner_settings_dto_spec.rb
+++ b/spec/sendgrid/helpers/settings/partner_settings_dto_spec.rb
@@ -11,14 +11,14 @@ describe SendGrid::PartnerSettingsDto do
   describe '.fetch' do
     it 'calls get on sendgrid_client' do
       args = { sendgrid_client: sendgrid_client, name: setting_name, query_params: {} }
-      expect(partner_settings.fetch(args)).to be_a SendGrid::Response
+      expect(partner_settings.fetch(**args)).to be_a SendGrid::Response
     end
   end
 
   describe '.update' do
     it 'calls patch on sendgrid_client' do
       args = { sendgrid_client: sendgrid_client, name: setting_name, request_body: setting_params }
-      expect(partner_settings.update(args)).to be_a SendGrid::Response
+      expect(partner_settings.update(**args)).to be_a SendGrid::Response
     end
   end
 end

--- a/spec/sendgrid/helpers/settings/tracking_settings_dto_spec.rb
+++ b/spec/sendgrid/helpers/settings/tracking_settings_dto_spec.rb
@@ -14,14 +14,14 @@ describe SendGrid::TrackingSettingsDto do
   describe '.fetch' do
     it 'calls get on sendgrid_client' do
       args = { sendgrid_client: sendgrid_client, name: setting_name, query_params: {} }
-      expect(tracking_settings.fetch(args)).to be_a SendGrid::Response
+      expect(tracking_settings.fetch(**args)).to be_a SendGrid::Response
     end
   end
 
   describe '.update' do
     it 'calls patch on sendgrid_client' do
       args = { sendgrid_client: sendgrid_client, name: setting_name, request_body: setting_params }
-      expect(tracking_settings.update(args)).to be_a SendGrid::Response
+      expect(tracking_settings.update(**args)).to be_a SendGrid::Response
     end
   end
 end

--- a/spec/sendgrid/helpers/settings/user_settings_dto_spec.rb
+++ b/spec/sendgrid/helpers/settings/user_settings_dto_spec.rb
@@ -11,14 +11,14 @@ describe SendGrid::UserSettingsDto do
   describe '.fetch' do
     it 'calls get on sendgrid_client' do
       args = { sendgrid_client: sendgrid_client, name: setting_name, query_params: {} }
-      expect(user_settings.fetch(args)).to be_a SendGrid::Response
+      expect(user_settings.fetch(**args)).to be_a SendGrid::Response
     end
   end
 
   describe '.update' do
     it 'calls patch on sendgrid_client' do
       args = { sendgrid_client: sendgrid_client, name: setting_name, request_body: setting_params }
-      expect(user_settings.update(args)).to be_a SendGrid::Response
+      expect(user_settings.update(**args)).to be_a SendGrid::Response
     end
   end
 end


### PR DESCRIPTION
https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/