### PR TITLE
docs Fix Email Activity listing example

### DIFF
--- a/examples/emailactivity/emailactivity.rb
+++ b/examples/emailactivity/emailactivity.rb
@@ -9,11 +9,10 @@ sg = SendGrid::API.new(api_key: ENV['SENDGRID_API_KEY'])
 require 'erb'
 
 filter_key = 'to_email'
-filter_operator = ERB::Util.url_encode('=')
-filter_value = 'testing@sendgrid.net'
-filter_value = ERB::Util.url_encode(format('"%s"', filter_value))
+filter_operator = '='
+filter_value = '\"testing@sendgrid.net\"'
 query_params = {}
-query_params['query'] = format("%s%s%s", filter_key, filter_operator, filter_value)
+query_params['query'] = [filter_key, filter_operator, filter_value].join
 query_params['limit'] = '1'
 
 params = query_params


### PR DESCRIPTION
While trying to query email activity, I ran into a problem.

The REST API documentation says that it needs to be URL escaped, but the API client escapes it for you. So this example effectively is double-escaping and won't work (it raises an API error with reports of being unable to parse the query).


**All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.**

Please enter each Issue number you are resolving in your PR after one of the following words [Fixes, Closes, Resolves]. 

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](https://github.com/sendgrid/sendgrid-ruby/blob/main/CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation about the functionality in the appropriate .md file
- [ ] I have added inline documentation to the code I modified