### PR TITLE
chore: Add Ruby 3.2 and JRuby 9.3 and 9.4 to CI.  Update checkout action versions

### DIFF
--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -16,18 +16,27 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     strategy:
+      fail-fast: false
       matrix:
-        ruby: [ '2.4', '2.5', '2.6', '2.7', '3.0', '3.1', 'jruby-9.2' ]
+        ruby: [ '2.4', '2.5', '2.6', '2.7', '3.0', '3.1', '3.2', 'jruby-9.2', 'jruby-9.3', 'jruby-9.4' ]
     env:
       version: ${{ format('ruby:{0}', matrix.ruby) }}
       DOCKER_LOGIN: ${{ secrets.DOCKER_USERNAME && secrets.DOCKER_AUTH_TOKEN }}
     steps:
-      - name: Revise env version if necessary
+      - name: Revise env version if necessary (jruby-9.2)
         run: echo "version=jruby:9.2" >> $GITHUB_ENV
         if: ${{ matrix.ruby == 'jruby-9.2' }}
 
+      - name: Revise env version if necessary (jruby-9.3)
+        run: echo "version=jruby:9.3" >> $GITHUB_ENV
+        if: ${{ matrix.ruby == 'jruby-9.3' }}
+
+      - name: Revise env version if necessary (jruby-9.4)
+        run: echo "version=jruby:9.4" >> $GITHUB_ENV
+        if: ${{ matrix.ruby == 'jruby-9.4' }}
+
       - name: Checkout sendgrid-ruby
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
@@ -66,7 +75,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sendgrid-ruby
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
Updates the CI matrix so it includes Ruby 3.2, JRuby 9.3, and JRuby 9.4
Also updates the checkout action version to eliminate the Node 12 warning on builds.

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](https://github.com/sendgrid/sendgrid-ruby/blob/main/CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation about the functionality in the appropriate .md file
- [x] I have added inline documentation to the code I modified

If you have questions, please file a [support ticket](https://support.sendgrid.com), or create a GitHub Issue in this repository.
