### PR TITLE
fix: use `Base64.strict_encode64` instead of `Base64.encode64`

### DIFF
--- a/lib/sendgrid/helpers/mail/attachment.rb
+++ b/lib/sendgrid/helpers/mail/attachment.rb
@@ -49,7 +49,7 @@ module SendGrid
       # in binary mode, but at least we can faithfully convey the
       # bytes.
       str = str.encode('UTF-8') unless io.respond_to?(:binmode?) && io.binmode?
-      Base64.encode64 str
+      Base64.strict_encode64 str
     end
   end
 end

--- a/mail_helper_v3.md
+++ b/mail_helper_v3.md
@@ -307,7 +307,7 @@ plain_text_content = 'and easy to do anywhere, even with Ruby'
 html_content = '<strong>and easy to do anywhere, even with Ruby</strong>'
 msg = SendGrid::Message.new(from, to, subject, plain_text_content, html_content)
 bytes = File.read('/path/to/the/attachment.pdf')
-encoded = Base64.encode64(bytes)
+encoded = Base64.strict_encode64(bytes)
 msg.add_attachment('balance_001.pdf',
                    encoded,
                    'application/pdf',

--- a/test/sendgrid/helpers/mail/test_attachment.rb
+++ b/test/sendgrid/helpers/mail/test_attachment.rb
@@ -18,13 +18,13 @@ Es blüht so grün wie Blüten blüh'n im Frühling
     attachment.content = StringIO.new(SAMPLE_INPUT)
 
     expected = {
-      "content" => "RXMgYmzDvGh0IHNvIGdyw7xuIHdpZSBCbMO8dGVuIGJsw7xoJ24gaW0gRnLD\nvGhsaW5nCkVzIGJsw7xodCBzbyBncsO8biB3aWUgQmzDvHRlbiBibMO8aCdu\nIGltIEZyw7xobGluZwpFcyBibMO8aHQgc28gZ3LDvG4gd2llIEJsw7x0ZW4g\nYmzDvGgnbiBpbSBGcsO8aGxpbmcKRXMgYmzDvGh0IHNvIGdyw7xuIHdpZSBC\nbMO8dGVuIGJsw7xoJ24gaW0gRnLDvGhsaW5nCkVzIGJsw7xodCBzbyBncsO8\nbiB3aWUgQmzDvHRlbiBibMO8aCduIGltIEZyw7xobGluZwo=\n"
+      "content" => "RXMgYmzDvGh0IHNvIGdyw7xuIHdpZSBCbMO8dGVuIGJsw7xoJ24gaW0gRnLDvGhsaW5nCkVzIGJsw7xodCBzbyBncsO8biB3aWUgQmzDvHRlbiBibMO8aCduIGltIEZyw7xobGluZwpFcyBibMO8aHQgc28gZ3LDvG4gd2llIEJsw7x0ZW4gYmzDvGgnbiBpbSBGcsO8aGxpbmcKRXMgYmzDvGh0IHNvIGdyw7xuIHdpZSBCbMO8dGVuIGJsw7xoJ24gaW0gRnLDvGhsaW5nCkVzIGJsw7xodCBzbyBncsO8biB3aWUgQmzDvHRlbiBibMO8aCduIGltIEZyw7xobGluZwo="
     }
 
     json = attachment.to_json
 
     # Double check that the decoded json matches original input.
-    decoded = Base64.decode64(json["content"]).force_encoding('UTF-8').encode
+    decoded = Base64.strict_decode64(json["content"]).force_encoding('UTF-8').encode
 
     assert_equal(decoded, SAMPLE_INPUT)
 


### PR DESCRIPTION
<!--
We appreciate the effort for this pull request but before that please make sure you read the contribution guidelines, then fill out the blanks below.

Please format the PR title appropriately based on the type of change:
  <type>[!]: <description>
Where <type> is one of: docs, chore, feat, fix, test, misc.
Add a '!' after the type for breaking changes (e.g. feat!: new breaking feature).

**All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.**

Please enter each Issue number you are resolving in your PR after one of the following words [Fixes, Closes, Resolves]. This will auto-link these issues and close them when this PR is merged!
e.g.
Fixes #1
Closes #2
-->

# Fixes #

I got the following error when using `Base64.encode64`.
``` json
{
  "errors": [
    {
      "message": "The attachment content must be base64 encoded.",
      "field": "attachments.0.content",
      "help": "http://sendgrid.com/docs/API_Reference/Web_API_v3/Mail/errors.html#message.attachments.content"
    }
  ]
}
```

It is resolved by changing to encode using `Base64.strict_encode64` where no line feeds are added`.

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [ ] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](https://github.com/sendgrid/sendgrid-ruby/blob/main/CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [x] I have added tests that prove my fix is effective or that my feature worksx
- [ ] I have added the necessary documentation about the functionality in the appropriate .md file
- [ ] I have added inline documentation to the code I modified

If you have questions, please file a [support ticket](https://support.sendgrid.com), or create a GitHub Issue in this repository.
