### PR TITLE
feat: geolocation setter in sendgrid-ruby for GDPR compliance

### DIFF
--- a/examples/dataresidency/setregion.rb
+++ b/examples/dataresidency/setregion.rb
@@ -9,7 +9,6 @@ subject = 'Sending with Twilio SendGrid is Fun'
 content = SendGrid::Content.new(type: 'text/plain', value: 'and easy to do anywhere, even with Ruby')
 mail = SendGrid::Mail.new(from, subject, to, content)
 sg = SendGrid::API.new(api_key: ENV['SENDGRID_API_KEY'])
-sg.data_residency("global")
 puts sg.host
 response = sg.client.mail._('send').post(request_body: mail.to_json)
 puts response.status_code
@@ -24,8 +23,8 @@ to = SendGrid::Email.new(email: 'example@abc.com')
 subject = 'Sending with Twilio SendGrid is Fun'
 content = SendGrid::Content.new(type: 'text/plain', value: 'and easy to do anywhere, even with Ruby')
 mail = SendGrid::Mail.new(from, subject, to, content)
-sg = SendGrid::API.new(api_key: ENV['SENDGRID_API_KEY'])
-sg.data_residency('eu')
+sg = SendGrid::API.new(api_key: ENV['SENDGRID_API_KEY_EU'])
+sg.data_residency(region: 'eu')
 puts sg.host
 response = sg.client.mail._('send').post(request_body: mail.to_json)
 puts response.status_code
@@ -70,7 +69,7 @@ to = SendGrid::Email.new(email: 'example@abc.com')
 subject = 'Sending with Twilio SendGrid is Fun'
 content = SendGrid::Content.new(type: 'text/plain', value: 'and easy to do anywhere, even with Ruby')
 mail = SendGrid::Mail.new(from, subject, to, content)
-sg = SendGrid::API.new(api_key: ENV['SENDGRID_API_KEY'], region: 'eu')
+sg = SendGrid::API.new(api_key: ENV['SENDGRID_API_KEY_EU'], region: 'eu')
 puts sg.host
 response = sg.client.mail._('send').post(request_body: mail.to_json)
 puts response.status_code
@@ -86,8 +85,24 @@ to = SendGrid::Email.new(email: 'example@abc.com')
 subject = 'Sending with Twilio SendGrid is Fun'
 content = SendGrid::Content.new(type: 'text/plain', value: 'and easy to do anywhere, even with Ruby')
 mail = SendGrid::Mail.new(from, subject, to, content)
+sg = SendGrid::API.new(api_key: ENV['SENDGRID_API_KEY_EU'])
+sg.data_residency(region: nil)
+puts sg.host
+response = sg.client.mail._('send').post(request_body: mail.to_json)
+puts response.status_code
+puts response.body
+puts response.headers
+
+# Example 7
+# First region, then host
+from = SendGrid::Email.new(email: 'example@abc.com')
+to = SendGrid::Email.new(email: 'example@abc.com')
+subject = 'Sending with Twilio SendGrid is Fun'
+content = SendGrid::Content.new(type: 'text/plain', value: 'and easy to do anywhere, even with Ruby')
+mail = SendGrid::Mail.new(from, subject, to, content)
 sg = SendGrid::API.new(api_key: ENV['SENDGRID_API_KEY'])
-sg.data_residency(nil)
+sg.data_residency(region: "eu")
+sg.update_host(host: "https://api.sendgrid.com")
 puts sg.host
 response = sg.client.mail._('send').post(request_body: mail.to_json)
 puts response.status_code

--- a/examples/dataresidency/setregion.rb
+++ b/examples/dataresidency/setregion.rb
@@ -1,5 +1,4 @@
-require sendgrid-ruby
-include SendGrid
+require_relative 'sendgrid-ruby'
 
 # Example 1
 # Sending using "global" data residency
@@ -71,14 +70,12 @@ to = SendGrid::Email.new(email: 'example@abc.com')
 subject = 'Sending with Twilio SendGrid is Fun'
 content = SendGrid::Content.new(type: 'text/plain', value: 'and easy to do anywhere, even with Ruby')
 mail = SendGrid::Mail.new(from, subject, to, content)
-sg = SendGrid::API.new(api_key: ENV['SENDGRID_API_KEY'],region: 'eu')
+sg = SendGrid::API.new(api_key: ENV['SENDGRID_API_KEY'], region: 'eu')
 puts sg.host
 response = sg.client.mail._('send').post(request_body: mail.to_json)
 puts response.status_code
 puts response.body
 puts response.headers
-
-
 
 # Example 6
 # Sending using "nil" data residency

--- a/examples/dataresidency/setregion.rb
+++ b/examples/dataresidency/setregion.rb
@@ -9,6 +9,7 @@ subject = 'Sending with Twilio SendGrid is Fun'
 content = SendGrid::Content.new(type: 'text/plain', value: 'and easy to do anywhere, even with Ruby')
 mail = SendGrid::Mail.new(from, subject, to, content)
 sg = SendGrid::API.new(api_key: ENV['SENDGRID_API_KEY'])
+sg.sendgrid_data_residency(region: "global")
 puts sg.host
 response = sg.client.mail._('send').post(request_body: mail.to_json)
 puts response.status_code
@@ -24,7 +25,7 @@ subject = 'Sending with Twilio SendGrid is Fun'
 content = SendGrid::Content.new(type: 'text/plain', value: 'and easy to do anywhere, even with Ruby')
 mail = SendGrid::Mail.new(from, subject, to, content)
 sg = SendGrid::API.new(api_key: ENV['SENDGRID_API_KEY_EU'])
-sg.data_residency(region: 'eu')
+sg.sendgrid_data_residency(region: 'eu')
 puts sg.host
 response = sg.client.mail._('send').post(request_body: mail.to_json)
 puts response.status_code
@@ -40,69 +41,6 @@ subject = 'Sending with Twilio SendGrid is Fun'
 content = SendGrid::Content.new(type: 'text/plain', value: 'and easy to do anywhere, even with Ruby')
 mail = SendGrid::Mail.new(from, subject, to, content)
 sg = SendGrid::API.new(api_key: ENV['SENDGRID_API_KEY'])
-puts sg.host
-response = sg.client.mail._('send').post(request_body: mail.to_json)
-puts response.status_code
-puts response.body
-puts response.headers
-
-# Example 4
-# Sending using "global" data residency in constructor
-
-from = SendGrid::Email.new(email: 'example@abc.com')
-to = SendGrid::Email.new(email: 'example@abc.com')
-subject = 'Sending with Twilio SendGrid is Fun'
-content = SendGrid::Content.new(type: 'text/plain', value: 'and easy to do anywhere, even with Ruby')
-mail = SendGrid::Mail.new(from, subject, to, content)
-sg = SendGrid::API.new(api_key: ENV['SENDGRID_API_KEY'], region: 'global')
-puts sg.host
-response = sg.client.mail._('send').post(request_body: mail.to_json)
-puts response.status_code
-puts response.body
-puts response.headers
-
-# Example 5
-# Sending using "eu" data residency in constructor
-
-from = SendGrid::Email.new(email: 'example@abc.com')
-to = SendGrid::Email.new(email: 'example@abc.com')
-subject = 'Sending with Twilio SendGrid is Fun'
-content = SendGrid::Content.new(type: 'text/plain', value: 'and easy to do anywhere, even with Ruby')
-mail = SendGrid::Mail.new(from, subject, to, content)
-sg = SendGrid::API.new(api_key: ENV['SENDGRID_API_KEY_EU'], region: 'eu')
-puts sg.host
-response = sg.client.mail._('send').post(request_body: mail.to_json)
-puts response.status_code
-puts response.body
-puts response.headers
-
-# Example 6
-# Sending using "nil" data residency
-# This will throw exception because data residency cannot be null
-
-from = SendGrid::Email.new(email: 'example@abc.com')
-to = SendGrid::Email.new(email: 'example@abc.com')
-subject = 'Sending with Twilio SendGrid is Fun'
-content = SendGrid::Content.new(type: 'text/plain', value: 'and easy to do anywhere, even with Ruby')
-mail = SendGrid::Mail.new(from, subject, to, content)
-sg = SendGrid::API.new(api_key: ENV['SENDGRID_API_KEY_EU'])
-sg.data_residency(region: nil)
-puts sg.host
-response = sg.client.mail._('send').post(request_body: mail.to_json)
-puts response.status_code
-puts response.body
-puts response.headers
-
-# Example 7
-# First region, then host
-from = SendGrid::Email.new(email: 'example@abc.com')
-to = SendGrid::Email.new(email: 'example@abc.com')
-subject = 'Sending with Twilio SendGrid is Fun'
-content = SendGrid::Content.new(type: 'text/plain', value: 'and easy to do anywhere, even with Ruby')
-mail = SendGrid::Mail.new(from, subject, to, content)
-sg = SendGrid::API.new(api_key: ENV['SENDGRID_API_KEY'])
-sg.data_residency(region: "eu")
-sg.update_host(host: "https://api.sendgrid.com")
 puts sg.host
 response = sg.client.mail._('send').post(request_body: mail.to_json)
 puts response.status_code

--- a/examples/dataresidency/setregion.rb
+++ b/examples/dataresidency/setregion.rb
@@ -1,0 +1,98 @@
+require sendgrid-ruby
+include SendGrid
+
+# Example 1
+# Sending using "global" data residency
+
+from = SendGrid::Email.new(email: 'example@abc.com')
+to = SendGrid::Email.new(email: 'example@abc.com')
+subject = 'Sending with Twilio SendGrid is Fun'
+content = SendGrid::Content.new(type: 'text/plain', value: 'and easy to do anywhere, even with Ruby')
+mail = SendGrid::Mail.new(from, subject, to, content)
+sg = SendGrid::API.new(api_key: ENV['SENDGRID_API_KEY'])
+sg.set_data_residency("global")
+puts sg.host
+response = sg.client.mail._('send').post(request_body: mail.to_json)
+puts response.status_code
+puts response.body
+puts response.headers
+
+# Example 2
+# Sending using "eu" data residency
+
+from = SendGrid::Email.new(email: 'example@abc.com')
+to = SendGrid::Email.new(email: 'example@abc.com')
+subject = 'Sending with Twilio SendGrid is Fun'
+content = SendGrid::Content.new(type: 'text/plain', value: 'and easy to do anywhere, even with Ruby')
+mail = SendGrid::Mail.new(from, subject, to, content)
+sg = SendGrid::API.new(api_key: ENV['SENDGRID_API_KEY'])
+sg.set_data_residency('eu')
+puts sg.host
+response = sg.client.mail._('send').post(request_body: mail.to_json)
+puts response.status_code
+puts response.body
+puts response.headers
+
+# Example 3
+# Sending using no data residency
+
+from = SendGrid::Email.new(email: 'example@abc.com')
+to = SendGrid::Email.new(email: 'example@abc.com')
+subject = 'Sending with Twilio SendGrid is Fun'
+content = SendGrid::Content.new(type: 'text/plain', value: 'and easy to do anywhere, even with Ruby')
+mail = SendGrid::Mail.new(from, subject, to, content)
+sg = SendGrid::API.new(api_key: ENV['SENDGRID_API_KEY'])
+puts sg.host
+response = sg.client.mail._('send').post(request_body: mail.to_json)
+puts response.status_code
+puts response.body
+puts response.headers
+
+# Example 4
+# Sending using "global" data residency in constructor
+
+from = SendGrid::Email.new(email: 'example@abc.com')
+to = SendGrid::Email.new(email: 'example@abc.com')
+subject = 'Sending with Twilio SendGrid is Fun'
+content = SendGrid::Content.new(type: 'text/plain', value: 'and easy to do anywhere, even with Ruby')
+mail = SendGrid::Mail.new(from, subject, to, content)
+sg = SendGrid::API.new(api_key: ENV['SENDGRID_API_KEY'], region: 'global')
+puts sg.host
+response = sg.client.mail._('send').post(request_body: mail.to_json)
+puts response.status_code
+puts response.body
+puts response.headers
+
+# Example 5
+# Sending using "eu" data residency in constructor
+
+from = SendGrid::Email.new(email: 'example@abc.com')
+to = SendGrid::Email.new(email: 'example@abc.com')
+subject = 'Sending with Twilio SendGrid is Fun'
+content = SendGrid::Content.new(type: 'text/plain', value: 'and easy to do anywhere, even with Ruby')
+mail = SendGrid::Mail.new(from, subject, to, content)
+sg = SendGrid::API.new(api_key: ENV['SENDGRID_API_KEY'],region: 'eu')
+puts sg.host
+response = sg.client.mail._('send').post(request_body: mail.to_json)
+puts response.status_code
+puts response.body
+puts response.headers
+
+
+
+# Example 6
+# Sending using "nil" data residency
+# This will throw exception because data residency cannot be null
+
+from = SendGrid::Email.new(email: 'example@abc.com')
+to = SendGrid::Email.new(email: 'example@abc.com')
+subject = 'Sending with Twilio SendGrid is Fun'
+content = SendGrid::Content.new(type: 'text/plain', value: 'and easy to do anywhere, even with Ruby')
+mail = SendGrid::Mail.new(from, subject, to, content)
+sg = SendGrid::API.new(api_key: ENV['SENDGRID_API_KEY'])
+sg.set_data_residency(nil)
+puts sg.host
+response = sg.client.mail._('send').post(request_body: mail.to_json)
+puts response.status_code
+puts response.body
+puts response.headers

--- a/examples/dataresidency/setregion.rb
+++ b/examples/dataresidency/setregion.rb
@@ -1,13 +1,10 @@
-# frozen_string_literal: true
-#require '/Users/manisingh/github/sendgrid/sendgrid-ruby'
-require_relative '/Users/manisingh/github/sendgrid/sendgrid-ruby/lib/sendgrid-ruby.rb'
-include SendGrid
+require 'sendgrid-ruby'
 
 # Example 1
 # Sending using "global" data residency
 
-from = SendGrid::Email.new(email: 'manisingh@twilio.com')
-to = SendGrid::Email.new(email: 'manisingh@twilio.com')
+from = SendGrid::Email.new(email: 'example@abc.com')
+to = SendGrid::Email.new(email: 'example@abc.com')
 subject = 'Sending with Twilio SendGrid is Fun'
 content = SendGrid::Content.new(type: 'text/plain', value: 'and easy to do anywhere, even with Ruby')
 mail = SendGrid::Mail.new(from, subject, to, content)
@@ -22,12 +19,12 @@ puts response.headers
 # Example 2
 # Sending using "eu" data residency
 
-from = SendGrid::Email.new(email: 'sburman@twilio.com')
-to = SendGrid::Email.new(email: 'sburman@twilio.com')
+from = SendGrid::Email.new(email: 'example@abc.com')
+to = SendGrid::Email.new(email: 'example@abc.com')
 subject = 'Sending with Twilio SendGrid is Fun'
 content = SendGrid::Content.new(type: 'text/plain', value: 'and easy to do anywhere, even with Ruby')
 mail = SendGrid::Mail.new(from, subject, to, content)
-sg = SendGrid::API.new(api_key: ENV['SENDGRID_API_KEY_EU'])
+sg = SendGrid::API.new(api_key: ENV['SENDGRID_API_KEY'])
 sg.data_residency('eu')
 puts sg.host
 response = sg.client.mail._('send').post(request_body: mail.to_json)
@@ -38,8 +35,8 @@ puts response.headers
 # Example 3
 # Sending using no data residency
 
-from = SendGrid::Email.new(email: 'manisingh@twilio.com')
-to = SendGrid::Email.new(email: 'manisingh@twilio.com')
+from = SendGrid::Email.new(email: 'example@abc.com')
+to = SendGrid::Email.new(email: 'example@abc.com')
 subject = 'Sending with Twilio SendGrid is Fun'
 content = SendGrid::Content.new(type: 'text/plain', value: 'and easy to do anywhere, even with Ruby')
 mail = SendGrid::Mail.new(from, subject, to, content)
@@ -53,8 +50,8 @@ puts response.headers
 # Example 4
 # Sending using "global" data residency in constructor
 
-from = SendGrid::Email.new(email: 'manisingh@twilio.com')
-to = SendGrid::Email.new(email: 'manisingh@twilio.com')
+from = SendGrid::Email.new(email: 'example@abc.com')
+to = SendGrid::Email.new(email: 'example@abc.com')
 subject = 'Sending with Twilio SendGrid is Fun'
 content = SendGrid::Content.new(type: 'text/plain', value: 'and easy to do anywhere, even with Ruby')
 mail = SendGrid::Mail.new(from, subject, to, content)
@@ -68,26 +65,24 @@ puts response.headers
 # Example 5
 # Sending using "eu" data residency in constructor
 
-from = SendGrid::Email.new(email: 'sburman@twilio.com')
-to = SendGrid::Email.new(email: 'sburman@twilio.com')
+from = SendGrid::Email.new(email: 'example@abc.com')
+to = SendGrid::Email.new(email: 'example@abc.com')
 subject = 'Sending with Twilio SendGrid is Fun'
 content = SendGrid::Content.new(type: 'text/plain', value: 'and easy to do anywhere, even with Ruby')
 mail = SendGrid::Mail.new(from, subject, to, content)
-sg = SendGrid::API.new(api_key: ENV['SENDGRID_API_KEY_EU'],region: 'eu')
+sg = SendGrid::API.new(api_key: ENV['SENDGRID_API_KEY'], region: 'eu')
 puts sg.host
 response = sg.client.mail._('send').post(request_body: mail.to_json)
 puts response.status_code
 puts response.body
 puts response.headers
 
-
-
 # Example 6
 # Sending using "nil" data residency
 # This will throw exception because data residency cannot be null
 
-from = SendGrid::Email.new(email: 'manisingh@twilio.com')
-to = SendGrid::Email.new(email: 'manisingh@twilio.com')
+from = SendGrid::Email.new(email: 'example@abc.com')
+to = SendGrid::Email.new(email: 'example@abc.com')
 subject = 'Sending with Twilio SendGrid is Fun'
 content = SendGrid::Content.new(type: 'text/plain', value: 'and easy to do anywhere, even with Ruby')
 mail = SendGrid::Mail.new(from, subject, to, content)

--- a/examples/dataresidency/setregion.rb
+++ b/examples/dataresidency/setregion.rb
@@ -1,10 +1,13 @@
-require 'sendgrid-ruby'
+# frozen_string_literal: true
+#require '/Users/manisingh/github/sendgrid/sendgrid-ruby'
+require_relative '/Users/manisingh/github/sendgrid/sendgrid-ruby/lib/sendgrid-ruby.rb'
+include SendGrid
 
 # Example 1
 # Sending using "global" data residency
 
-from = SendGrid::Email.new(email: 'example@abc.com')
-to = SendGrid::Email.new(email: 'example@abc.com')
+from = SendGrid::Email.new(email: 'manisingh@twilio.com')
+to = SendGrid::Email.new(email: 'manisingh@twilio.com')
 subject = 'Sending with Twilio SendGrid is Fun'
 content = SendGrid::Content.new(type: 'text/plain', value: 'and easy to do anywhere, even with Ruby')
 mail = SendGrid::Mail.new(from, subject, to, content)
@@ -19,12 +22,12 @@ puts response.headers
 # Example 2
 # Sending using "eu" data residency
 
-from = SendGrid::Email.new(email: 'example@abc.com')
-to = SendGrid::Email.new(email: 'example@abc.com')
+from = SendGrid::Email.new(email: 'sburman@twilio.com')
+to = SendGrid::Email.new(email: 'sburman@twilio.com')
 subject = 'Sending with Twilio SendGrid is Fun'
 content = SendGrid::Content.new(type: 'text/plain', value: 'and easy to do anywhere, even with Ruby')
 mail = SendGrid::Mail.new(from, subject, to, content)
-sg = SendGrid::API.new(api_key: ENV['SENDGRID_API_KEY'])
+sg = SendGrid::API.new(api_key: ENV['SENDGRID_API_KEY_EU'])
 sg.data_residency('eu')
 puts sg.host
 response = sg.client.mail._('send').post(request_body: mail.to_json)
@@ -35,8 +38,8 @@ puts response.headers
 # Example 3
 # Sending using no data residency
 
-from = SendGrid::Email.new(email: 'example@abc.com')
-to = SendGrid::Email.new(email: 'example@abc.com')
+from = SendGrid::Email.new(email: 'manisingh@twilio.com')
+to = SendGrid::Email.new(email: 'manisingh@twilio.com')
 subject = 'Sending with Twilio SendGrid is Fun'
 content = SendGrid::Content.new(type: 'text/plain', value: 'and easy to do anywhere, even with Ruby')
 mail = SendGrid::Mail.new(from, subject, to, content)
@@ -50,8 +53,8 @@ puts response.headers
 # Example 4
 # Sending using "global" data residency in constructor
 
-from = SendGrid::Email.new(email: 'example@abc.com')
-to = SendGrid::Email.new(email: 'example@abc.com')
+from = SendGrid::Email.new(email: 'manisingh@twilio.com')
+to = SendGrid::Email.new(email: 'manisingh@twilio.com')
 subject = 'Sending with Twilio SendGrid is Fun'
 content = SendGrid::Content.new(type: 'text/plain', value: 'and easy to do anywhere, even with Ruby')
 mail = SendGrid::Mail.new(from, subject, to, content)
@@ -65,24 +68,26 @@ puts response.headers
 # Example 5
 # Sending using "eu" data residency in constructor
 
-from = SendGrid::Email.new(email: 'example@abc.com')
-to = SendGrid::Email.new(email: 'example@abc.com')
+from = SendGrid::Email.new(email: 'sburman@twilio.com')
+to = SendGrid::Email.new(email: 'sburman@twilio.com')
 subject = 'Sending with Twilio SendGrid is Fun'
 content = SendGrid::Content.new(type: 'text/plain', value: 'and easy to do anywhere, even with Ruby')
 mail = SendGrid::Mail.new(from, subject, to, content)
-sg = SendGrid::API.new(api_key: ENV['SENDGRID_API_KEY'], region: 'eu')
+sg = SendGrid::API.new(api_key: ENV['SENDGRID_API_KEY_EU'],region: 'eu')
 puts sg.host
 response = sg.client.mail._('send').post(request_body: mail.to_json)
 puts response.status_code
 puts response.body
 puts response.headers
 
+
+
 # Example 6
 # Sending using "nil" data residency
 # This will throw exception because data residency cannot be null
 
-from = SendGrid::Email.new(email: 'example@abc.com')
-to = SendGrid::Email.new(email: 'example@abc.com')
+from = SendGrid::Email.new(email: 'manisingh@twilio.com')
+to = SendGrid::Email.new(email: 'manisingh@twilio.com')
 subject = 'Sending with Twilio SendGrid is Fun'
 content = SendGrid::Content.new(type: 'text/plain', value: 'and easy to do anywhere, even with Ruby')
 mail = SendGrid::Mail.new(from, subject, to, content)

--- a/examples/dataresidency/setregion.rb
+++ b/examples/dataresidency/setregion.rb
@@ -1,4 +1,4 @@
-require_relative 'sendgrid-ruby'
+require 'sendgrid-ruby'
 
 # Example 1
 # Sending using "global" data residency
@@ -9,7 +9,7 @@ subject = 'Sending with Twilio SendGrid is Fun'
 content = SendGrid::Content.new(type: 'text/plain', value: 'and easy to do anywhere, even with Ruby')
 mail = SendGrid::Mail.new(from, subject, to, content)
 sg = SendGrid::API.new(api_key: ENV['SENDGRID_API_KEY'])
-sg.set_data_residency("global")
+sg.data_residency("global")
 puts sg.host
 response = sg.client.mail._('send').post(request_body: mail.to_json)
 puts response.status_code
@@ -25,7 +25,7 @@ subject = 'Sending with Twilio SendGrid is Fun'
 content = SendGrid::Content.new(type: 'text/plain', value: 'and easy to do anywhere, even with Ruby')
 mail = SendGrid::Mail.new(from, subject, to, content)
 sg = SendGrid::API.new(api_key: ENV['SENDGRID_API_KEY'])
-sg.set_data_residency('eu')
+sg.data_residency('eu')
 puts sg.host
 response = sg.client.mail._('send').post(request_body: mail.to_json)
 puts response.status_code
@@ -87,7 +87,7 @@ subject = 'Sending with Twilio SendGrid is Fun'
 content = SendGrid::Content.new(type: 'text/plain', value: 'and easy to do anywhere, even with Ruby')
 mail = SendGrid::Mail.new(from, subject, to, content)
 sg = SendGrid::API.new(api_key: ENV['SENDGRID_API_KEY'])
-sg.set_data_residency(nil)
+sg.data_residency(nil)
 puts sg.host
 response = sg.client.mail._('send').post(request_body: mail.to_json)
 puts response.status_code

--- a/lib/sendgrid/base_interface.rb
+++ b/lib/sendgrid/base_interface.rb
@@ -16,14 +16,14 @@ class BaseInterface
   #                              in the "On-Behalf-Of" header
   #   - +http_options+ -> http options that you want to be globally applied to each request
   #
-  def initialize(auth:, host: nil, region: nil, request_headers: nil, version: nil, impersonate_subuser: nil, http_options: {})
+  def initialize(auth:, host: , region: nil, request_headers: nil, version: nil, impersonate_subuser: nil, http_options: {})
     @auth = auth
     if host.nil? && region.nil?
       @host = "https://api.sendgrid.com"
     elsif !region.nil?
       data_residency(region: region)
     else
-      update_host(host: host)
+      @host = host
     end
     @version = version || 'v3'
     @impersonate_subuser = impersonate_subuser

--- a/lib/sendgrid/base_interface.rb
+++ b/lib/sendgrid/base_interface.rb
@@ -51,9 +51,7 @@ class BaseInterface
 
   def data_residency(region)
     region_host_dict = { "eu" => 'https://api.eu.sendgrid.com', "global" => 'https://api.sendgrid.com' }
-    if region.nil? || !region_host_dict.key?(region)
-      raise ArgumentError, "region can only be \"eu\" or \"global\""
-    end
+    raise ArgumentError, "region can only be \"eu\" or \"global\"" if region.nil? || !region_host_dict.key?(region)
 
     @host = region_host_dict[region]
     @client = SendGrid::Client.new(host: "#{@host}/#{@version}",

--- a/lib/sendgrid/base_interface.rb
+++ b/lib/sendgrid/base_interface.rb
@@ -19,7 +19,7 @@ class BaseInterface
   def initialize(auth:, host: nil, region: nil, request_headers: nil, version: nil, impersonate_subuser: nil, http_options: {})
     @auth = auth
     if host.nil? && region.nil?
-      @host="https://api.sendgrid.com"
+      @host = "https://api.sendgrid.com"
     elsif !region.nil?
       data_residency(region: region)
     else

--- a/lib/sendgrid/base_interface.rb
+++ b/lib/sendgrid/base_interface.rb
@@ -18,9 +18,7 @@ class BaseInterface
   #
   def initialize(auth:, host:, region: nil, request_headers: nil, version: nil, impersonate_subuser: nil, http_options: {})
     @auth = auth
-    if host.nil? && region.nil?
-      @host = "https://api.sendgrid.com"
-    elsif !region.nil?
+    if !region.nil?
       data_residency(region: region)
     else
       @host = host

--- a/lib/sendgrid/base_interface.rb
+++ b/lib/sendgrid/base_interface.rb
@@ -51,7 +51,7 @@ class BaseInterface
 
     @host = region_host_dict[region]
     @client = SendGrid::Client.new(host: "#{@host}/#{@version}",
-                  request_headers: @request_headers,
-                  http_options: @http_options)
+                                   request_headers: @request_headers,
+                                   http_options: @http_options)
   end
 end

--- a/lib/sendgrid/base_interface.rb
+++ b/lib/sendgrid/base_interface.rb
@@ -16,12 +16,14 @@ class BaseInterface
   #                              in the "On-Behalf-Of" header
   #   - +http_options+ -> http options that you want to be globally applied to each request
   #
-  def initialize(auth:, host:, region: 'global', request_headers: nil, version: nil, impersonate_subuser: nil, http_options: {})
+  def initialize(auth:, host: nil, region: nil, request_headers: nil, version: nil, impersonate_subuser: nil, http_options: {})
     @auth = auth
-    if !host.nil?
-      update_host(host)
+    if host.nil? && region.nil?
+      @host="https://api.sendgrid.com"
+    elsif !region.nil?
+      data_residency(region: region)
     else
-      data_residency(region)
+      update_host(host: host)
     end
     @version = version || 'v3'
     @impersonate_subuser = impersonate_subuser
@@ -42,14 +44,13 @@ class BaseInterface
                                    http_options: @http_options)
   end
 
-  def update_host(host)
+  def update_host(host:)
     @host = host
     @client = SendGrid::Client.new(host: "#{@host}/#{@version}",
                                    request_headers: @request_headers,
                                    http_options: @http_options)
   end
-
-  def data_residency(region)
+  def data_residency(region:)
     region_host_dict = { "eu" => 'https://api.eu.sendgrid.com', "global" => 'https://api.sendgrid.com' }
     raise ArgumentError, "region can only be \"eu\" or \"global\"" if region.nil? || !region_host_dict.key?(region)
 

--- a/lib/sendgrid/base_interface.rb
+++ b/lib/sendgrid/base_interface.rb
@@ -46,8 +46,8 @@ class BaseInterface
   end
 
   def set_data_residency(region)
-    region_host_dict = {"eu" => 'https://api.eu.sendgrid.com',"global" => 'https://api.sendgrid.com'}
-    if( region == nil || !region_host_dict.has_key?(region) )
+    region_host_dict = { "eu" => 'https://api.eu.sendgrid.com', "global" => 'https://api.sendgrid.com' }
+    if ( region.nil? || !region_host_dict.has_key?(region) )
       raise ArgumentError, "region can only be \"eu\" or \"global\""
     end
     @host = region_host_dict[region]

--- a/lib/sendgrid/base_interface.rb
+++ b/lib/sendgrid/base_interface.rb
@@ -16,9 +16,9 @@ class BaseInterface
   #                              in the "On-Behalf-Of" header
   #   - +http_options+ -> http options that you want to be globally applied to each request
   #
-  def initialize(auth:, host:, region:'global', request_headers: nil, version: nil, impersonate_subuser: nil, http_options: {})
+  def initialize(auth:, host:, region: 'global', request_headers: nil, version: nil, impersonate_subuser: nil, http_options: {})
     @auth = auth
-    if not host.nil?
+    if !host.nil?
       update_host(host)
     else
       data_residency(region)
@@ -59,6 +59,5 @@ class BaseInterface
     @client = SendGrid::Client.new(host: "#{@host}/#{@version}",
                                    request_headers: @request_headers,
                                    http_options: @http_options)
-    return region_host_dict[region]
   end
 end

--- a/lib/sendgrid/base_interface.rb
+++ b/lib/sendgrid/base_interface.rb
@@ -37,4 +37,23 @@ class BaseInterface
                                    request_headers: @request_headers,
                                    http_options: @http_options)
   end
+
+  def set_host(host)
+    @host = host
+    @client = SendGrid::Client.new(host: "#{@host}/#{@version}",
+                                   request_headers: @request_headers,
+                                   http_options: @http_options)
+  end
+
+  def set_data_residency(region)
+    region_host_dict = {"eu" => 'https://api.eu.sendgrid.com',"global" => 'https://api.sendgrid.com'}
+    if( region == nil || !region_host_dict.has_key?(region) )
+      raise ArgumentError, "region can only be \"eu\" or \"global\""
+    end
+    @host = region_host_dict[region]
+    @client = SendGrid::Client.new(host: "#{@host}/#{@version}",
+                                   request_headers: @request_headers,
+                                   http_options: @http_options)
+    return region_host_dict[region]
+  end
 end

--- a/lib/sendgrid/base_interface.rb
+++ b/lib/sendgrid/base_interface.rb
@@ -38,14 +38,14 @@ class BaseInterface
                                    http_options: @http_options)
   end
 
-  def set_host(host)
+  def setHost(host)
     @host = host
     @client = SendGrid::Client.new(host: "#{@host}/#{@version}",
                                    request_headers: @request_headers,
                                    http_options: @http_options)
   end
 
-  def set_data_residency(region)
+  def data_residency(region)
     region_host_dict = { "eu" => 'https://api.eu.sendgrid.com', "global" => 'https://api.sendgrid.com' }
     if ( region.nil? || !region_host_dict.has_key?(region) )
       raise ArgumentError, "region can only be \"eu\" or \"global\""

--- a/lib/sendgrid/base_interface.rb
+++ b/lib/sendgrid/base_interface.rb
@@ -50,6 +50,7 @@ class BaseInterface
                                    request_headers: @request_headers,
                                    http_options: @http_options)
   end
+
   def data_residency(region:)
     region_host_dict = { "eu" => 'https://api.eu.sendgrid.com', "global" => 'https://api.sendgrid.com' }
     raise ArgumentError, "region can only be \"eu\" or \"global\"" if region.nil? || !region_host_dict.key?(region)

--- a/lib/sendgrid/base_interface.rb
+++ b/lib/sendgrid/base_interface.rb
@@ -16,7 +16,7 @@ class BaseInterface
   #                              in the "On-Behalf-Of" header
   #   - +http_options+ -> http options that you want to be globally applied to each request
   #
-  def initialize(auth:, host: , region: nil, request_headers: nil, version: nil, impersonate_subuser: nil, http_options: {})
+  def initialize(auth:, host:, region: nil, request_headers: nil, version: nil, impersonate_subuser: nil, http_options: {})
     @auth = auth
     if host.nil? && region.nil?
       @host = "https://api.sendgrid.com"

--- a/lib/sendgrid/sendgrid.rb
+++ b/lib/sendgrid/sendgrid.rb
@@ -14,6 +14,7 @@ module SendGrid
     def initialize(api_key:, host: nil, request_headers: nil, version: nil, impersonate_subuser: nil, http_options: {})
       auth = "Bearer #{api_key}"
       host ||= 'https://api.sendgrid.com'
+
       super(auth: auth, host: host, request_headers: request_headers, version: version, impersonate_subuser: impersonate_subuser, http_options: http_options)
     end
   end

--- a/lib/sendgrid/sendgrid.rb
+++ b/lib/sendgrid/sendgrid.rb
@@ -14,6 +14,7 @@ module SendGrid
     #
     def initialize(api_key:, host: nil, region: nil, request_headers: nil, version: nil, impersonate_subuser: nil, http_options: {})
       auth = "Bearer #{api_key}"
+      host ||= 'https://api.sendgrid.com'
       super(auth: auth, host: host, region: region, request_headers: request_headers, version: version, impersonate_subuser: impersonate_subuser, http_options: http_options)
     end
   end

--- a/lib/sendgrid/sendgrid.rb
+++ b/lib/sendgrid/sendgrid.rb
@@ -12,10 +12,9 @@ module SendGrid
     #   - +http_options+ -> http options that you want to be globally applied to each request
     #   - +region+ -> data residency. The values only be either 'eu' or 'global'.
     #
-    def initialize(api_key:, region: nil, host: nil, request_headers: nil, version: nil, impersonate_subuser: nil, http_options: {})
+    def initialize(api_key:, host: nil,region: 'global', request_headers: nil, version: nil, impersonate_subuser: nil, http_options: {})
       auth = "Bearer #{api_key}"
-      host_with_data_residency = host == nil ? ( region == nil ? "https://api.sendgrid.com" : data_residency(region) ) : host
-      super(auth: auth, host: host_with_data_residency, request_headers: request_headers, version: version, impersonate_subuser: impersonate_subuser, http_options: http_options)
+      super(auth: auth, host: host,region:region, request_headers: request_headers, version: version, impersonate_subuser: impersonate_subuser, http_options: http_options)
     end
   end
 end

--- a/lib/sendgrid/sendgrid.rb
+++ b/lib/sendgrid/sendgrid.rb
@@ -12,7 +12,7 @@ module SendGrid
     #   - +http_options+ -> http options that you want to be globally applied to each request
     #   - +region+ -> data residency. The values only be either 'eu' or 'global'.
     #
-    def initialize(api_key:, host: nil, region: 'global', request_headers: nil, version: nil, impersonate_subuser: nil, http_options: {})
+    def initialize(api_key:, host: nil, region: nil, request_headers: nil, version: nil, impersonate_subuser: nil, http_options: {})
       auth = "Bearer #{api_key}"
       super(auth: auth, host: host, region: region, request_headers: request_headers, version: version, impersonate_subuser: impersonate_subuser, http_options: http_options)
     end

--- a/lib/sendgrid/sendgrid.rb
+++ b/lib/sendgrid/sendgrid.rb
@@ -12,9 +12,9 @@ module SendGrid
     #   - +http_options+ -> http options that you want to be globally applied to each request
     #   - +region+ -> data residency. The values only be either 'eu' or 'global'.
     #
-    def initialize(api_key:, host: nil,region: 'global', request_headers: nil, version: nil, impersonate_subuser: nil, http_options: {})
+    def initialize(api_key:, host: nil, region: 'global', request_headers: nil, version: nil, impersonate_subuser: nil, http_options: {})
       auth = "Bearer #{api_key}"
-      super(auth: auth, host: host,region:region, request_headers: request_headers, version: version, impersonate_subuser: impersonate_subuser, http_options: http_options)
+      super(auth: auth, host: host, region:region, request_headers: request_headers, version: version, impersonate_subuser: impersonate_subuser, http_options: http_options)
     end
   end
 end

--- a/lib/sendgrid/sendgrid.rb
+++ b/lib/sendgrid/sendgrid.rb
@@ -10,12 +10,11 @@ module SendGrid
     #   - +impersonate_subuser+ -> the subuser to impersonate, will be passed
     #                              in the "On-Behalf-Of" header
     #   - +http_options+ -> http options that you want to be globally applied to each request
-    #   - +region+ -> data residency. The values only be either 'eu' or 'global'.
     #
-    def initialize(api_key:, host: nil, region: nil, request_headers: nil, version: nil, impersonate_subuser: nil, http_options: {})
+    def initialize(api_key:, host: nil, request_headers: nil, version: nil, impersonate_subuser: nil, http_options: {})
       auth = "Bearer #{api_key}"
       host ||= 'https://api.sendgrid.com'
-      super(auth: auth, host: host, region: region, request_headers: request_headers, version: version, impersonate_subuser: impersonate_subuser, http_options: http_options)
+      super(auth: auth, host: host, request_headers: request_headers, version: version, impersonate_subuser: impersonate_subuser, http_options: http_options)
     end
   end
 end

--- a/lib/sendgrid/sendgrid.rb
+++ b/lib/sendgrid/sendgrid.rb
@@ -14,7 +14,7 @@ module SendGrid
     #
     def initialize(api_key:, host: nil, region: 'global', request_headers: nil, version: nil, impersonate_subuser: nil, http_options: {})
       auth = "Bearer #{api_key}"
-      super(auth: auth, host: host, region:region, request_headers: request_headers, version: version, impersonate_subuser: impersonate_subuser, http_options: http_options)
+      super(auth: auth, host: host, region: region, request_headers: request_headers, version: version, impersonate_subuser: impersonate_subuser, http_options: http_options)
     end
   end
 end

--- a/lib/sendgrid/sendgrid.rb
+++ b/lib/sendgrid/sendgrid.rb
@@ -14,7 +14,7 @@ module SendGrid
     #
     def initialize(api_key:, region: nil, host: nil, request_headers: nil, version: nil, impersonate_subuser: nil, http_options: {})
       auth = "Bearer #{api_key}"
-      host_with_data_residency = host == nil ? ( region == nil ? "https://api.sendgrid.com" : set_data_residency(region) ) : host
+      host_with_data_residency = host == nil ? ( region == nil ? "https://api.sendgrid.com" : data_residency(region) ) : host
       super(auth: auth, host: host_with_data_residency, request_headers: request_headers, version: version, impersonate_subuser: impersonate_subuser, http_options: http_options)
     end
   end

--- a/lib/sendgrid/sendgrid.rb
+++ b/lib/sendgrid/sendgrid.rb
@@ -10,12 +10,12 @@ module SendGrid
     #   - +impersonate_subuser+ -> the subuser to impersonate, will be passed
     #                              in the "On-Behalf-Of" header
     #   - +http_options+ -> http options that you want to be globally applied to each request
+    #   - +region+ -> data residency. The values only be either 'eu' or 'global'.
     #
-    def initialize(api_key:, host: nil, request_headers: nil, version: nil, impersonate_subuser: nil, http_options: {})
+    def initialize(api_key:, region: nil, host: nil, request_headers: nil, version: nil, impersonate_subuser: nil, http_options: {})
       auth = "Bearer #{api_key}"
-      host ||= 'https://api.sendgrid.com'
-
-      super(auth: auth, host: host, request_headers: request_headers, version: version, impersonate_subuser: impersonate_subuser, http_options: http_options)
+      host_with_data_residency = host == nil ? ( region == nil ? "https://api.sendgrid.com" : set_data_residency(region) ) : host
+      super(auth: auth, host: host_with_data_residency, request_headers: request_headers, version: version, impersonate_subuser: impersonate_subuser, http_options: http_options)
     end
   end
 end

--- a/test/sendgrid/helpers/mail/test_data_residency.rb
+++ b/test/sendgrid/helpers/mail/test_data_residency.rb
@@ -1,45 +1,47 @@
-require_relative '../../../../lib/sendgrid-ruby.rb'
+require_relative '../../../../lib/sendgrid-ruby'
 require 'minitest/autorun'
 
 class TestDataResidency < Minitest::Test
   include SendGrid
 
   def setup
-    @globalEmail = 'https://api.sendgrid.com'
-    @euEmail = 'https://api.eu.sendgrid.com'
+    @global_email = 'https://api.sendgrid.com'
+    @eu_email = 'https://api.eu.sendgrid.com'
   end
+
   def test_with_global_data_residency
     sg = SendGrid::API.new(api_key: ENV['SENDGRID_API_KEY'])
     sg.data_residency('global')
-    assert_equal @globalEmail, sg.host
+    assert_equal @global_email, sg.host
   end
 
   def test_with_global_data_residency_in_constructor
     sg = SendGrid::API.new(api_key: ENV['SENDGRID_API_KEY'], region: 'global')
-    assert_equal @globalEmail, sg.host
+    assert_equal @global_email, sg.host
   end
 
   def test_with_global_eu_residency
     sg = SendGrid::API.new(api_key: ENV['SENDGRID_API_KEY'])
     sg.data_residency('eu')
-    assert_equal @euEmail, sg.host
+    assert_equal @eu_email, sg.host
   end
+
   def test_with_global_eu_residency_in_constructor
     sg = SendGrid::API.new(api_key: ENV['SENDGRID_API_KEY'], region: 'eu')
-    assert_equal @euEmail, sg.host
+    assert_equal @eu_email, sg.host
   end
 
   def test_with_host_set_first_and_residency_set_second
     sg = SendGrid::API.new(api_key: ENV['SENDGRID_API_KEY'], region: 'eu')
-    sg.setHost("https://api.test.sendgrid.com")
+    sg.update_host("https://api.test.sendgrid.com")
     sg.data_residency("eu")
-    assert_equal @euEmail, sg.host
+    assert_equal @eu_email, sg.host
   end
 
   def test_with_residency_set_first_and_host_set_second
     sg = SendGrid::API.new(api_key: ENV['SENDGRID_API_KEY'], region: 'eu')
     sg.data_residency("eu")
-    sg.setHost("https://api.test.sendgrid.com")
+    sg.update_host("https://api.test.sendgrid.com")
     assert_equal "https://api.test.sendgrid.com", sg.host
   end
 

--- a/test/sendgrid/helpers/mail/test_data_residency.rb
+++ b/test/sendgrid/helpers/mail/test_data_residency.rb
@@ -47,5 +47,4 @@ class TestDataResidency < Minitest::Test
     sg.sendgrid_data_residency(region: '')
     assert_equal @eu_email, sg.host
   end
-
 end

--- a/test/sendgrid/helpers/mail/test_data_residency.rb
+++ b/test/sendgrid/helpers/mail/test_data_residency.rb
@@ -67,7 +67,7 @@ class TestDataResidency < Minitest::Test
   end
 
   def test_host_with_both_host_and_region_in_constructor
-    sg = SendGrid::API.new(api_key: ENV['SENDGRID_API_KEY'],host: "https://example.com",region: "eu")
+    sg = SendGrid::API.new(api_key: ENV['SENDGRID_API_KEY'], host: "https://example.com", region: "eu")
     assert_equal @eu_email, sg.host
   end
 end

--- a/test/sendgrid/helpers/mail/test_data_residency.rb
+++ b/test/sendgrid/helpers/mail/test_data_residency.rb
@@ -11,7 +11,7 @@ class TestDataResidency < Minitest::Test
 
   def test_with_global_data_residency
     sg = SendGrid::API.new(api_key: ENV['SENDGRID_API_KEY'])
-    sg.data_residency('global')
+    sg.data_residency(region: 'global')
     assert_equal @global_email, sg.host
   end
 
@@ -22,7 +22,7 @@ class TestDataResidency < Minitest::Test
 
   def test_with_global_eu_residency
     sg = SendGrid::API.new(api_key: ENV['SENDGRID_API_KEY'])
-    sg.data_residency('eu')
+    sg.data_residency(region: 'eu')
     assert_equal @eu_email, sg.host
   end
 
@@ -33,36 +33,41 @@ class TestDataResidency < Minitest::Test
 
   def test_with_host_set_first_and_residency_set_second
     sg = SendGrid::API.new(api_key: ENV['SENDGRID_API_KEY'], region: 'eu')
-    sg.update_host("https://api.test.sendgrid.com")
-    sg.data_residency("eu")
+    sg.update_host(host: "https://api.test.sendgrid.com")
+    sg.data_residency(region: "eu")
     assert_equal @eu_email, sg.host
   end
 
   def test_with_residency_set_first_and_host_set_second
     sg = SendGrid::API.new(api_key: ENV['SENDGRID_API_KEY'], region: 'eu')
-    sg.data_residency("eu")
-    sg.update_host("https://api.test.sendgrid.com")
+    sg.data_residency(region: "eu")
+    sg.update_host(host: "https://api.test.sendgrid.com")
     assert_equal "https://api.test.sendgrid.com", sg.host
   end
 
   def test_with_global_nil_residency
     sg = SendGrid::API.new(api_key: ENV['SENDGRID_API_KEY'])
     assert_raises(ArgumentError) do
-      sg.data_residency(nil)
+      sg.data_residency(region: nil)
     end
   end
 
   def test_with_global_invalid_residency
     sg = SendGrid::API.new(api_key: ENV['SENDGRID_API_KEY'])
     assert_raises(ArgumentError) do
-      sg.data_residency("abc")
+      sg.data_residency(region: "abc")
     end
   end
 
   def test_with_global_empty_residency
     sg = SendGrid::API.new(api_key: ENV['SENDGRID_API_KEY'])
     assert_raises(ArgumentError) do
-      sg.data_residency("")
+      sg.data_residency(region: "")
     end
+  end
+
+  def test_host_with_both_host_and_region_in_constructor
+    sg = SendGrid::API.new(api_key: ENV['SENDGRID_API_KEY'],host: "https://example.com",region: "eu")
+    assert_equal @eu_email, sg.host
   end
 end

--- a/test/sendgrid/helpers/mail/test_data_residency.rb
+++ b/test/sendgrid/helpers/mail/test_data_residency.rb
@@ -11,63 +11,41 @@ class TestDataResidency < Minitest::Test
 
   def test_with_global_data_residency
     sg = SendGrid::API.new(api_key: ENV['SENDGRID_API_KEY'])
-    sg.data_residency(region: 'global')
-    assert_equal @global_email, sg.host
-  end
-
-  def test_with_global_data_residency_in_constructor
-    sg = SendGrid::API.new(api_key: ENV['SENDGRID_API_KEY'], region: 'global')
+    sg.sendgrid_data_residency(region: 'global')
     assert_equal @global_email, sg.host
   end
 
   def test_with_global_eu_residency
     sg = SendGrid::API.new(api_key: ENV['SENDGRID_API_KEY'])
-    sg.data_residency(region: 'eu')
+    sg.sendgrid_data_residency(region: 'eu')
     assert_equal @eu_email, sg.host
-  end
-
-  def test_with_global_eu_residency_in_constructor
-    sg = SendGrid::API.new(api_key: ENV['SENDGRID_API_KEY'], region: 'eu')
-    assert_equal @eu_email, sg.host
-  end
-
-  def test_with_host_set_first_and_residency_set_second
-    sg = SendGrid::API.new(api_key: ENV['SENDGRID_API_KEY'], region: 'eu')
-    sg.update_host(host: "https://api.test.sendgrid.com")
-    sg.data_residency(region: "eu")
-    assert_equal @eu_email, sg.host
-  end
-
-  def test_with_residency_set_first_and_host_set_second
-    sg = SendGrid::API.new(api_key: ENV['SENDGRID_API_KEY'], region: 'eu')
-    sg.data_residency(region: "eu")
-    sg.update_host(host: "https://api.test.sendgrid.com")
-    assert_equal "https://api.test.sendgrid.com", sg.host
   end
 
   def test_with_global_nil_residency
     sg = SendGrid::API.new(api_key: ENV['SENDGRID_API_KEY'])
     assert_raises(ArgumentError) do
-      sg.data_residency(region: nil)
+      sg.sendgrid_data_residency(region: nil)
     end
   end
 
   def test_with_global_invalid_residency
     sg = SendGrid::API.new(api_key: ENV['SENDGRID_API_KEY'])
     assert_raises(ArgumentError) do
-      sg.data_residency(region: "abc")
+      sg.sendgrid_data_residency(region: "abc")
     end
   end
 
   def test_with_global_empty_residency
     sg = SendGrid::API.new(api_key: ENV['SENDGRID_API_KEY'])
     assert_raises(ArgumentError) do
-      sg.data_residency(region: "")
+      sg.sendgrid_data_residency(region: "")
     end
   end
 
-  def test_host_with_both_host_and_region_in_constructor
-    sg = SendGrid::API.new(api_key: ENV['SENDGRID_API_KEY'], host: "https://example.com", region: "eu")
+  def test_with_global_eu_residency
+    sg = SendGrid::API.new(api_key: ENV['SENDGRID_API_KEY'])
+    sg.sendgrid_data_residency(region: '')
     assert_equal @eu_email, sg.host
   end
+
 end

--- a/test/sendgrid/helpers/mail/test_data_residency.rb
+++ b/test/sendgrid/helpers/mail/test_data_residency.rb
@@ -65,5 +65,4 @@ class TestDataResidency < Minitest::Test
       sg.data_residency("")
     end
   end
-
 end

--- a/test/sendgrid/helpers/mail/test_data_residency.rb
+++ b/test/sendgrid/helpers/mail/test_data_residency.rb
@@ -1,0 +1,67 @@
+require_relative '../../../../lib/sendgrid-ruby.rb'
+require 'minitest/autorun'
+
+class TestDataResidency < Minitest::Test
+  include SendGrid
+
+  def setup
+    @globalEmail = 'https://api.sendgrid.com'
+    @euEmail = 'https://api.eu.sendgrid.com'
+  end
+  def test_with_global_data_residency
+    sg = SendGrid::API.new(api_key: ENV['SENDGRID_API_KEY'])
+    sg.set_data_residency('global')
+    assert_equal @globalEmail,sg.host
+  end
+
+  def test_with_global_data_residency_in_constructor
+    sg = SendGrid::API.new(api_key: ENV['SENDGRID_API_KEY'],region: 'global')
+    assert_equal @globalEmail,sg.host
+  end
+
+  def test_with_global_eu_residency
+    sg = SendGrid::API.new(api_key: ENV['SENDGRID_API_KEY'])
+    sg.set_data_residency('eu')
+    assert_equal @euEmail,sg.host
+  end
+  def test_with_global_eu_residency_in_constructor
+    sg = SendGrid::API.new(api_key: ENV['SENDGRID_API_KEY'], region: 'eu')
+    assert_equal @euEmail,sg.host
+  end
+
+  def test_with_host_set_first_and_residency_set_second
+    sg = SendGrid::API.new(api_key: ENV['SENDGRID_API_KEY'], region: 'eu')
+    sg.set_host("https://api.test.sendgrid.com")
+    sg.set_data_residency("eu")
+    assert_equal @euEmail,sg.host
+  end
+
+  def test_with_residency_set_first_and_host_set_second
+    sg = SendGrid::API.new(api_key: ENV['SENDGRID_API_KEY'], region: 'eu')
+    sg.set_data_residency("eu")
+    sg.set_host("https://api.test.sendgrid.com")
+    assert_equal "https://api.test.sendgrid.com",sg.host
+  end
+
+  def test_with_global_nil_residency
+    sg = SendGrid::API.new(api_key: ENV['SENDGRID_API_KEY'])
+    assert_raises(ArgumentError) do
+      sg.set_data_residency(nil)
+    end
+  end
+
+  def test_with_global_invalid_residency
+    sg = SendGrid::API.new(api_key: ENV['SENDGRID_API_KEY'])
+    assert_raises(ArgumentError) do
+      sg.set_data_residency("abc")
+    end
+  end
+
+  def test_with_global_empty_residency
+    sg = SendGrid::API.new(api_key: ENV['SENDGRID_API_KEY'])
+    assert_raises(ArgumentError) do
+      sg.set_data_residency("")
+    end
+  end
+
+end

--- a/test/sendgrid/helpers/mail/test_data_residency.rb
+++ b/test/sendgrid/helpers/mail/test_data_residency.rb
@@ -41,10 +41,4 @@ class TestDataResidency < Minitest::Test
       sg.sendgrid_data_residency(region: "")
     end
   end
-
-  def test_with_failure
-    sg = SendGrid::API.new(api_key: ENV['SENDGRID_API_KEY'])
-    sg.sendgrid_data_residency(region: '')
-    assert_equal @eu_email, sg.host
-  end
 end

--- a/test/sendgrid/helpers/mail/test_data_residency.rb
+++ b/test/sendgrid/helpers/mail/test_data_residency.rb
@@ -10,18 +10,18 @@ class TestDataResidency < Minitest::Test
   end
   def test_with_global_data_residency
     sg = SendGrid::API.new(api_key: ENV['SENDGRID_API_KEY'])
-    sg.set_data_residency('global')
+    sg.data_residency('global')
     assert_equal @globalEmail, sg.host
   end
 
   def test_with_global_data_residency_in_constructor
-    sg = SendGrid::API.new(api_key: ENV['SENDGRID_API_KEY'],region: 'global')
+    sg = SendGrid::API.new(api_key: ENV['SENDGRID_API_KEY'], region: 'global')
     assert_equal @globalEmail, sg.host
   end
 
   def test_with_global_eu_residency
     sg = SendGrid::API.new(api_key: ENV['SENDGRID_API_KEY'])
-    sg.set_data_residency('eu')
+    sg.data_residency('eu')
     assert_equal @euEmail, sg.host
   end
   def test_with_global_eu_residency_in_constructor
@@ -31,36 +31,36 @@ class TestDataResidency < Minitest::Test
 
   def test_with_host_set_first_and_residency_set_second
     sg = SendGrid::API.new(api_key: ENV['SENDGRID_API_KEY'], region: 'eu')
-    sg.set_host("https://api.test.sendgrid.com")
-    sg.set_data_residency("eu")
+    sg.setHost("https://api.test.sendgrid.com")
+    sg.data_residency("eu")
     assert_equal @euEmail, sg.host
   end
 
   def test_with_residency_set_first_and_host_set_second
     sg = SendGrid::API.new(api_key: ENV['SENDGRID_API_KEY'], region: 'eu')
-    sg.set_data_residency("eu")
-    sg.set_host("https://api.test.sendgrid.com")
+    sg.data_residency("eu")
+    sg.setHost("https://api.test.sendgrid.com")
     assert_equal "https://api.test.sendgrid.com", sg.host
   end
 
   def test_with_global_nil_residency
     sg = SendGrid::API.new(api_key: ENV['SENDGRID_API_KEY'])
     assert_raises(ArgumentError) do
-      sg.set_data_residency(nil)
+      sg.data_residency(nil)
     end
   end
 
   def test_with_global_invalid_residency
     sg = SendGrid::API.new(api_key: ENV['SENDGRID_API_KEY'])
     assert_raises(ArgumentError) do
-      sg.set_data_residency("abc")
+      sg.data_residency("abc")
     end
   end
 
   def test_with_global_empty_residency
     sg = SendGrid::API.new(api_key: ENV['SENDGRID_API_KEY'])
     assert_raises(ArgumentError) do
-      sg.set_data_residency("")
+      sg.data_residency("")
     end
   end
 

--- a/test/sendgrid/helpers/mail/test_data_residency.rb
+++ b/test/sendgrid/helpers/mail/test_data_residency.rb
@@ -42,7 +42,7 @@ class TestDataResidency < Minitest::Test
     end
   end
 
-  def test_with_global_eu_residency
+  def test_with_failure
     sg = SendGrid::API.new(api_key: ENV['SENDGRID_API_KEY'])
     sg.sendgrid_data_residency(region: '')
     assert_equal @eu_email, sg.host

--- a/test/sendgrid/helpers/mail/test_data_residency.rb
+++ b/test/sendgrid/helpers/mail/test_data_residency.rb
@@ -11,36 +11,36 @@ class TestDataResidency < Minitest::Test
   def test_with_global_data_residency
     sg = SendGrid::API.new(api_key: ENV['SENDGRID_API_KEY'])
     sg.set_data_residency('global')
-    assert_equal @globalEmail,sg.host
+    assert_equal @globalEmail, sg.host
   end
 
   def test_with_global_data_residency_in_constructor
     sg = SendGrid::API.new(api_key: ENV['SENDGRID_API_KEY'],region: 'global')
-    assert_equal @globalEmail,sg.host
+    assert_equal @globalEmail, sg.host
   end
 
   def test_with_global_eu_residency
     sg = SendGrid::API.new(api_key: ENV['SENDGRID_API_KEY'])
     sg.set_data_residency('eu')
-    assert_equal @euEmail,sg.host
+    assert_equal @euEmail, sg.host
   end
   def test_with_global_eu_residency_in_constructor
     sg = SendGrid::API.new(api_key: ENV['SENDGRID_API_KEY'], region: 'eu')
-    assert_equal @euEmail,sg.host
+    assert_equal @euEmail, sg.host
   end
 
   def test_with_host_set_first_and_residency_set_second
     sg = SendGrid::API.new(api_key: ENV['SENDGRID_API_KEY'], region: 'eu')
     sg.set_host("https://api.test.sendgrid.com")
     sg.set_data_residency("eu")
-    assert_equal @euEmail,sg.host
+    assert_equal @euEmail, sg.host
   end
 
   def test_with_residency_set_first_and_host_set_second
     sg = SendGrid::API.new(api_key: ENV['SENDGRID_API_KEY'], region: 'eu')
     sg.set_data_residency("eu")
     sg.set_host("https://api.test.sendgrid.com")
-    assert_equal "https://api.test.sendgrid.com",sg.host
+    assert_equal "https://api.test.sendgrid.com", sg.host
   end
 
   def test_with_global_nil_residency


### PR DESCRIPTION
feat!: Geolocation setter for sendgrid ruby
Ticket: [DII-1232](https://issues.corp.twilio.com/browse/DII-1232)

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](https://github.com/sendgrid/sendgrid-ruby/blob/main/CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation about the functionality in the appropriate .md file
- [x] I have added inline documentation to the code I modified

