### PR TITLE
chore: Add base64 to gemspec

### DIFF
--- a/sendgrid-ruby.gemspec
+++ b/sendgrid-ruby.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(/^(test|spec|features)/)
   spec.require_paths = ['lib']
   spec.add_dependency 'ruby_http_client', '~> 3.4'
+  spec.add_dependency 'base64'
   spec.add_development_dependency 'faker'
   spec.add_development_dependency 'minitest', '~> 5.9'
   spec.add_development_dependency 'pry'


### PR DESCRIPTION
# Fixes #

Add base64 to gemspec, which is no longer the default gem from Ruby 3.4.
In fact, when I run the `make test` command on Ruby 3.3  I get the warning.

```
warning: base64 was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0. Add base64 to your Gemfile or gemspec.
```
# References

* similar support in rails/rails: https://github.com/rails/rails/pull/48907
* bugs.ruby-lang: https://bugs.ruby-lang.org/issues/19776
* ruby/ruby: https://github.com/ruby/ruby/pull/8126


### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [ ] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](https://github.com/sendgrid/sendgrid-ruby/blob/main/CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation about the functionality in the appropriate .md file
- [ ] I have added inline documentation to the code I modified

If you have questions, please file a [support ticket](https://support.sendgrid.com), or create a GitHub Issue in this repository.
