### PR TITLE
fix: Exclude tests and related files from gem package

### DIFF
--- a/sendgrid-ruby.gemspec
+++ b/sendgrid-ruby.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.2'
 
   spec.license = 'MIT'
-  spec.files         = `git ls-files -z`.split("\x0")
+  spec.files         = `git ls-files -z`.split("\x0").grep_v(%r{^(gemfiles|spec|test)/})
   spec.executables   = spec.files.grep(/^bin/) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(/^(test|spec|features)/)
   spec.require_paths = ['lib']


### PR DESCRIPTION
Here's a patch that excludes files under `spec`, `test`, and `gemfiles` directory from the gem package.

With this patch, the gem package size shrinks as follows:
```
before: 246272 bytes
after:  229376 bytes
```

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [ ] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](https://github.com/sendgrid/sendgrid-ruby/blob/main/CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation about the functionality in the appropriate .md file
- [ ] I have added inline documentation to the code I modified