### PR TITLE
fix: Correct some minor typos

### DIFF
--- a/examples/helpers/eventwebhook/example.rb
+++ b/examples/helpers/eventwebhook/example.rb
@@ -1,4 +1,4 @@
-require 'sengrid-ruby'
+require 'sendgrid-ruby'
 include SendGrid
 
 def is_valid_signature(request)

--- a/examples/mail/mail.rb
+++ b/examples/mail/mail.rb
@@ -160,7 +160,7 @@ data = JSON.parse('{
       "enable": true,
       "html": "If you would like to unsubscribe and stop receiving these emails <% clickhere %>.",
       "substitution_tag": "<%click here%>",
-      "text": "If you would like to unsubscribe and stop receiveing these emails <% click here %>."
+      "text": "If you would like to unsubscribe and stop receiving these emails <% click here %>."
     }
   }
 }')

--- a/lib/sendgrid/helpers/inbound/app.rb
+++ b/lib/sendgrid/helpers/inbound/app.rb
@@ -2,7 +2,7 @@ begin
   require 'sinatra'
 rescue LoadError
   puts <<-NOTE
-    As of sengrid verison 6, sinatra is no longer specified as a dependency of
+    As of sengrid version 6, sinatra is no longer specified as a dependency of
     the sendgrid gem. All the functionality of the inbound server is still the same
     and fully supported, but you just need to include the sinatra dependency in your gemfile
     yourself, like so:

--- a/lib/sendgrid/helpers/inbound/app.rb
+++ b/lib/sendgrid/helpers/inbound/app.rb
@@ -2,7 +2,7 @@ begin
   require 'sinatra'
 rescue LoadError
   puts <<-NOTE
-    As of sengrid version 6, sinatra is no longer specified as a dependency of
+    As of sendgrid version 6, sinatra is no longer specified as a dependency of
     the sendgrid gem. All the functionality of the inbound server is still the same
     and fully supported, but you just need to include the sinatra dependency in your gemfile
     yourself, like so:

--- a/lib/sendgrid/helpers/inbound/app.rb
+++ b/lib/sendgrid/helpers/inbound/app.rb
@@ -3,7 +3,7 @@ begin
 rescue LoadError
   puts <<-NOTE
     As of sendgrid version 6, sinatra is no longer specified as a dependency of
-    the sendgrid gem. All the functionality of the inbound server is still the same
+    the sendgrid gem. All the functionality of the Inbound server is still the same
     and fully supported, but you just need to include the sinatra dependency in your gemfile
     yourself, like so:
 

--- a/lib/sendgrid/helpers/inbound/public/index.html
+++ b/lib/sendgrid/helpers/inbound/public/index.html
@@ -3,7 +3,7 @@
     <title>Twilio SendGrid Incoming Parse</title>
   </head>
   <body>
-    <h1>You have successfuly launched the server!</h1>
+    <h1>You have successfully launched the server!</h1>
 
        Check out <a href="https://github.com/sendgrid/sendgrid-ruby/tree/HEAD/sendgrid/helpers/inbound">the documentation</a> on how to use this software to utilize the SendGrid Inbound Parse webhook.
   </body>

--- a/spec/rack/sendgrid_webhook_verification_spec.rb
+++ b/spec/rack/sendgrid_webhook_verification_spec.rb
@@ -124,7 +124,7 @@ unless RUBY_PLATFORM == 'java'
 
       let(:middleware) { Rack::SendGridWebhookVerification.new(@spy_app, public_key, %r{/email}) }
 
-      it 'keeps orignal reading position' do
+      it 'keeps original reading position' do
         options = {
           :input => Fixtures::EventWebhook::PAYLOAD,
           'Content-Type' => "application/json"

--- a/test/sendgrid/test_sendgrid-ruby.rb
+++ b/test/sendgrid/test_sendgrid-ruby.rb
@@ -1260,7 +1260,7 @@ class TestAPI < MiniTest::Test
   "enable": true,
   "html": "If you would like to unsubscribe and stop receiving these emails <% clickhere %>.",
   "substitution_tag": "<%click here%>",
-  "text": "If you would like to unsubscribe and stop receiveing these emails <% click here %>."
+  "text": "If you would like to unsubscribe and stop receiving these emails <% click here %>."
 }
 }
 }')


### PR DESCRIPTION
Fix some minor typos.
- [orignal ==> original](https://github.com/sendgrid/sendgrid-ruby/commit/bf419cfdaabc21d503b74d355d1f653f2ea1e568)
- [receiveing ==> receiving](https://github.com/sendgrid/sendgrid-ruby/commit/45f96433d8c43a58daf6de70dddaabcaaccf6ea8)
- [successfuly ==> successfully](https://github.com/sendgrid/sendgrid-ruby/commit/ca5c3a59375cefbcd088c8d217331c203f0681f8)
- [verison ==> version](https://github.com/sendgrid/sendgrid-ruby/commit/a7cd44851f25db44963728bcdb198dcb30fc30e5)
- [sengrid ==> sendgrid](https://github.com/sendgrid/sendgrid-ruby/commit/e5257a9de0a1c8189ca8fd623553d4502f15e37d)
- [sengrid-ruby ==> sendgrid-ruby](https://github.com/sendgrid/sendgrid-ruby/commit/a7807bb41127debf7e22d184510c19a99b9d3c5c)
- [inbound server ==> Inbound server](https://github.com/sendgrid/sendgrid-ruby/pull/503/commits/264c7e1219ebf7727ee916a156bbed505ff7d037)